### PR TITLE
pass roomName to SwapRoom config

### DIFF
--- a/src/swap.room/SwapRoom.js
+++ b/src/swap.room/SwapRoom.js
@@ -10,7 +10,7 @@ class SwapRoom extends ServiceInterface {
   constructor(config) {
     super()
 
-    if (!config || typeof config !== 'object') {
+    if (!config || typeof config !== 'object' || typeof config.ipfs !== 'object') {
       throw new Error('SwapRoomService: "config" of type object required')
     }
 
@@ -30,7 +30,12 @@ class SwapRoom extends ServiceInterface {
       throw new Error('SwapRoomService: IpfsRoom required')
     }
 
-    const ipfs = new SwapApp.env.Ipfs(this._config)
+    const ipfs = new SwapApp.env.Ipfs({
+      EXPERIMENTAL: {
+        pubsub: true,
+      },
+      config: this._config.ipfs
+    })
 
     ipfs.once('error', (err) => {
       console.log('IPFS error!', err)
@@ -52,9 +57,11 @@ class SwapRoom extends ServiceInterface {
 
   _init({ peer, ipfsConnection }) {
     this.peer = peer
-    this.roomName = SwapApp.isMainNet()
+    const defaultRoomName = SwapApp.isMainNet()
                   ? 'swap.online'
                   : 'testnet.swap.online'
+
+    this.roomName = this._config.roomName || defaultRoomName
 
     console.log(`Using room: ${this.roomName}`)
 

--- a/src/swap.room/SwapRoom.js
+++ b/src/swap.room/SwapRoom.js
@@ -10,7 +10,7 @@ class SwapRoom extends ServiceInterface {
   constructor(config) {
     super()
 
-    if (!config || typeof config !== 'object' || typeof config.ipfs !== 'object') {
+    if (!config || typeof config !== 'object' || typeof config.config !== 'object') {
       throw new Error('SwapRoomService: "config" of type object required')
     }
 
@@ -30,11 +30,13 @@ class SwapRoom extends ServiceInterface {
       throw new Error('SwapRoomService: IpfsRoom required')
     }
 
+    const { roomName, EXPERIMENTAL, ...config } = this._config
+
     const ipfs = new SwapApp.env.Ipfs({
       EXPERIMENTAL: {
         pubsub: true,
       },
-      config: this._config.ipfs
+      ...config,
     })
 
     ipfs.once('error', (err) => {

--- a/tests/config.js
+++ b/tests/config.js
@@ -2,7 +2,7 @@ const request = require('superagent')
 
 module.exports = {
   swapRoom: {
-    // roomName: 'swap.core.tests.swap.online',
+    roomName: 'swap.core.tests.swap.online',
     EXPERIMENTAL: {
       pubsub: true
     },

--- a/tests/swap.test.js
+++ b/tests/swap.test.js
@@ -23,7 +23,7 @@ test('check app loaded', () => {
 })
 
 test('sets the right type of room', () => {
-  expect(app.services.room.roomName).toBe('testnet.swap.online')
+  expect(app.services.room.roomName).toBe('swap.core.tests.swap.online')
 })
 
 test('create an order', async () => {


### PR DESCRIPTION
Было
```javascript
  new SwapRoom({
    EXPERIMENTAL: {
      pubsub: true
    },
    config: {
      Addresses: {
        Swarm: [
          '/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star',
        ],
      },
    },
  }),
```
Стало
```javascript
  new SwapRoom({
    roomName: 'swap.core.tests.swap.online',
    // EXPERIMENTAL можно пропустить
    config: {
      Addresses: {
        Swarm: [
          '/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star',
        ],
      },
    },
  }),
```