### PR TITLE
Fund BTC Script directly

### DIFF
--- a/src/swap.flows/BTC2ETHTOKEN.js
+++ b/src/swap.flows/BTC2ETHTOKEN.js
@@ -34,8 +34,6 @@ export default (tokenName) => {
 
       this.ethTokenSwap = swap.ownerSwap
       this.btcSwap      = swap.participantSwap
-
-      this.allowFundBTCDirectly = false;
       
       if (!this.ethTokenSwap) {
         throw new Error('BTC2ETH: "ethTokenSwap" of type object required')
@@ -77,7 +75,7 @@ export default (tokenName) => {
       super._persistSteps()
       this._persistState()
     }
-
+    
     _persistState() {
       super._persistState()
     }
@@ -115,52 +113,33 @@ export default (tokenName) => {
           }
         },
 
-        // 2. Create secret, secret hash
+        // 2. Create secret, secret hash and BTC script
 
         () => {
           // this.submitSecret()
         },
 
-        // 3. Check balance
+        // 3. Check system wallet balance
 
         () => {
           this.syncBalance()
         },
 
-        // 4. Create BTC Script, fund, notify participant
+        // 4. Fund BTC Script if balance enough - else infinity loop BTC balance check, notify participant
 
         async () => {
-          const { sellAmount, participant } = flow.swap
+          const { sellAmount } = flow.swap
+          
           let btcScriptCreatingTransactionHash
 
-          // TODO move this somewhere!
-          const utcNow = () => Math.floor(Date.now() / 1000)
-          const getLockTime = () => utcNow() + 3600 * 3 // 3 hours from now
-
-          const scriptValues = {
-            secretHash:         flow.state.secretHash,
-            ownerPublicKey:     SwapApp.services.auth.accounts.btc.getPublicKey(),
-            recipientPublicKey: participant.btc.publicKey,
-            lockTime:           getLockTime(),
-          }
-          if (flow.state.isBalanceEnough) {
-            await flow.btcSwap.fundScript({
-              scriptValues,
-              amount: sellAmount,
-            }, (hash) => {
-              btcScriptCreatingTransactionHash = hash
-
-              flow.setState({
-                btcScriptCreatingTransactionHash: hash,
-              })
-            })
+          const onBTCFuncSuccess = (txID) => {
 
             flow.swap.room.on('request btc script', () => {
               flow.swap.room.sendMessage({
                 event:  'create btc script',
                 data: {
-                  scriptValues,
-                  btcScriptCreatingTransactionHash,
+                  scriptValues : flow.state.btcScriptValues,
+                  btcScriptCreatingTransactionHash : txID,
                 }
               })
             })
@@ -168,22 +147,69 @@ export default (tokenName) => {
             flow.swap.room.sendMessage({
               event: 'create btc script',
               data: {
-                scriptValues,
-                btcScriptCreatingTransactionHash,
+                scriptValues : flow.state.btcScriptValues,
+                btcScriptCreatingTransactionHash : txID,
               }
             })
 
             flow.finishStep({
-              isBtcScriptFunded: true,
-              btcScriptValues: scriptValues,
+              isBtcScriptFunded: true
             }, {  step: 'lock-btc' })
+          }
+          
+          // Balance on system wallet enough
+          if (flow.state.isBalanceEnough) {
+            await flow.btcSwap.fundScript({
+              scriptValues : flow.state.btcScriptValues,
+              amount: sellAmount,
+            }, (hash) => {
+              btcScriptCreatingTransactionHash = hash
+
+              flow.setState({
+                btcScriptCreatingTransactionHash: hash,
+              })
+              
+              onBTCFuncSuccess(hash)
+            })
           } else {
-            const scriptData = flow.btcSwap.createScript(scriptValues)
-            flow.setState( {
-              scriptData : scriptData,
-              scriptBalance : 0,
-              scriptUnspendBlance : 0
-            } );
+            let btcCheckTimer;
+            
+            const checkBTCScriptBalance = () => {
+              btcCheckTimer = setTimeout( async () => {
+                const { sellAmount } = flow.swap
+                
+                let txID = false
+                
+                const unspends = await this.btcSwap.fetchUnspents(flow.state.scriptAddress);
+                if (unspends.length)
+                  txID = unspends[0].txID;
+                
+                const unconfirmedTotalSatoshi = BigInt(unspends.reduce( ( summ, txData ) => {
+                  return summ + (!txData.confirmations) ? txData.satoshis : 0;
+                } , 0 ));
+                const unconfirmedTotal = unspends.reduce( ( summ, txData ) => {
+                  return summ + (!txData.confirmations) ? txData.amount : 0;
+                } , 0 );
+                
+                const balance = await this.btcSwap.getBalance(flow.state.scriptAddress);
+                
+                const balanceSatoshi = BigInt(balance*1e8);
+                
+                flow.setState({
+                  scriptBalance : balance,
+                  scriptUnconfirmedBalance : unconfirmedTotal
+                });
+                const balanceOnScript = balanceSatoshi + unconfirmedTotalSatoshi + BigInt(this.btcSwap.getTxFee( true ) );
+                const isEnoughMoney = sellAmount.multipliedBy(1e8).isLessThanOrEqualTo( balanceOnScript );
+                
+                if (isEnoughMoney) {
+                  onBTCFuncSuccess(txID)
+                } else {
+                  checkBTCScriptBalance()
+                }
+              }, 20 * 1000)
+            }
+            checkBTCScriptBalance();
           }
         },
 
@@ -198,27 +224,16 @@ export default (tokenName) => {
               ethSwapCreationTransactionHash,
             })
           })
-
-          const checkEthBalance = () => {
-            timer = setTimeout(async () => {
-              const balance = await flow.ethTokenSwap.getBalance({
-                ownerAddress: participant.eth.address,
-              })
-
-              if (balance > 0) {
-                if (!flow.state.isEthContractFunded) { // redundant condition but who cares :D
-                  flow.finishStep({
-                    isEthContractFunded: true,
-                  }, { step: 'wait-lock-eth' })
-                }
+          
+          flow.waitEthBalance().then( (balance) => {
+            if (balance > 0) {
+              if (!flow.state.isEthContractFunded) { // redundant condition but who cares :D
+                flow.finishStep({
+                  isEthContractFunded: true,
+                }, { step: 'wait-lock-eth' })
               }
-              else {
-                checkEthBalance()
-              }
-            }, 20 * 1000)
-          }
-
-          checkEthBalance()
+            }
+          } );
 
           flow.swap.room.once('create eth contract', () => {
             if (!flow.state.isEthContractFunded) {
@@ -242,17 +257,22 @@ export default (tokenName) => {
             secret:         flow.state.secret,
           }
 
-          const balanceCheckResult = await flow.ethTokenSwap.checkBalance({
-            ownerAddress: participant.eth.address,
-            expectedValue: buyAmount,
-          })
-
-          if (balanceCheckResult) {
+          const balanceCheckResult = await flow.waitEthBalance();
+          if (!balanceCheckResult) {
             console.error(`Waiting until deposit: ETH balance check error:`, balanceCheckResult)
             flow.swap.events.dispatch('eth balance check error', balanceCheckResult)
             return
           }
-
+          
+          const targetWallet = await flow.ethTokenSwap.getTargetWallet( participant.eth.address );
+          const needTargetWallet = (flow.swap.destinationBuyAddress) ? flow.swap.destinationBuyAddress : SwapApp.services.auth.accounts.eth.address;
+          
+          if (targetWallet != needTargetWallet) {
+            console.error("Destination address for tokens dismatch with needed (Needed, Getted). Stop swap now!",needTargetWallet,targetWallet);
+            flow.swap.events.dispatch('address for tokens invalid', { needed : needTargetWallet, getted : targetWallet });
+            return
+          }
+          
           try {
             await flow.ethTokenSwap.withdraw(data, (hash) => {
               flow.setState({
@@ -306,7 +326,28 @@ export default (tokenName) => {
         }
       ]
     }
+    
+    async waitEthBalance() {
+      const flow = this;
+      const participant = this.swap.participant;
+      
+      return new Promise((resolve, reject) => {
+        const checkEthBalance =  async () => {
+          const balance = await flow.ethTokenSwap.getBalance({
+            ownerAddress: participant.eth.address,
+          })
+          if (balance > 0) {
+            resolve( balance );
+          }
+          else {
+            setTimeout( checkEthBalance, 20 * 1000 );
+          }
+        }
 
+        checkEthBalance()
+      } );
+    }
+    
     submitSecret(secret) {
       if (this.state.secretHash) { return }
 
@@ -316,69 +357,46 @@ export default (tokenName) => {
 
       const secretHash = crypto.ripemd160(Buffer.from(secret, 'hex')).toString('hex')
 
+      /* Secret hash generated - create BTC script - and only after this notify other part */
+      this.createWorkBTCScript(secretHash);
+      
       this.finishStep({
         secret,
         secretHash,
       }, { step: 'submit-secret' })
     }
-
-    async checkScriptBalance() {
-      if (!this.state.isBalanceEnough) {
-        const { sellAmount } = this.swap
-
-        this.setState({
-          isBalanceFetching: true,
-          isBalanceEnough: false,
-        });
-        const balance = await this.btcSwap.fetchBalance(this.state.scriptData.scriptAddress);
-        this.setState({
-          scriptBalance : balance
-        });
-        const unspend = await this.btcSwap.fetchUnspents(this.state.scriptData.scriptAddress);
-        let unspendTotal = 0;
-        for (var i in unspend) {
-          if (!unspend.confirmations) {
-            unspendTotal = unspendTotal+unspend[i].amount;
-          }
-        };
-        const isEnoughMoney = sellAmount.isLessThanOrEqualTo(balance+unspendTotal+this.btcSwap.getTxFee());
-        this.setState( {
-          scriptUnspendBlance : unspendTotal,
-          isBalanceFetching : false,
-          isBalanceEnough: isEnoughMoney,
-        } );
-        if (isEnoughMoney) {
-          const flow = this;
-          const scriptValues = flow.state.btcScriptValues
-          const btcScriptCreatingTransactionHash = flow.state.scriptData.scriptAddress;
-          
-          flow.setState({
-            btcScriptCreatingTransactionHash: flow.state.scriptData.scriptAddress,
-          })
-
-          flow.swap.room.on('request btc script', () => {
-            flow.swap.room.sendMessage({
-              event:  'create btc script',
-              data: {
-                scriptValues,
-                btcScriptCreatingTransactionHash,
-              }
-            })
-          })
-
-          flow.swap.room.sendMessage({
-            event: 'create btc script',
-            data: {
-              scriptValues,
-              btcScriptCreatingTransactionHash,
-            }
-          })
-
-          flow.finishStep({
-            isBtcScriptFunded: true
-          })
-        }
+    
+    getBTCScriptAddress() {
+      return this.state.scriptAddress;
+    }
+    createWorkBTCScript(secretHash) {
+      if (this.state.btcScriptValues) {
+        console.log('BTC Script already generated',this.state.btcScriptValues);
+        return;
       }
+      const { participant } = this.swap
+      // TODO move this somewhere!
+      const utcNow = () => Math.floor(Date.now() / 1000)
+      const getLockTime = () => utcNow() + 3600 * 3 // 3 hours from now
+      
+      const scriptValues = {
+        secretHash:         secretHash,
+        ownerPublicKey:     SwapApp.services.auth.accounts.btc.getPublicKey(),
+        recipientPublicKey: participant.btc.publicKey,
+        lockTime:           getLockTime(),
+      }
+      const scriptData = this.btcSwap.createScript(scriptValues)
+      
+      this.setState( {
+        scriptAddress : scriptData.scriptAddress,
+        btcScriptValues: scriptValues,
+        scriptBalance : 0,
+        scriptUnspendBalance : 0
+      } );
+    }
+    
+    async checkScriptBalance() {
+      console.log("BTC2ETHTOKEN checkScriptBalance - nothing do - empty :p - wait infinity loop");
     }
 
     async syncBalance() {
@@ -391,29 +409,14 @@ export default (tokenName) => {
       const balance = await this.btcSwap.fetchBalance(SwapApp.services.auth.accounts.btc.getAddress())
       const isEnoughMoney = sellAmount.isLessThanOrEqualTo(balance)
 
-      if (isEnoughMoney) {
-        this.finishStep({
-          balance,
-          isBalanceFetching: false,
-          isBalanceEnough: true,
-        }, { step: 'sync-balance' })
+      if (!isEnoughMoney) {
+        console.error(`Not enough money: ${balance} < ${sellAmount}`)
       }
-      else {
-        if (this.allowFundBTCDirectly) {
-          this.finishStep({
-            balance,
-            isBalanceFetching: false,
-            isBalanceEnough: false,
-          }, { step: 'sync-balance' })
-        } else {
-          console.error(`Not enough money: ${balance} < ${sellAmount}`)
-          this.setState({
-            balance,
-            isBalanceFetching: false,
-            isBalanceEnough: false,
-          })
-        }
-      }
+      this.finishStep({
+        balance,
+        isBalanceFetching: false,
+        isBalanceEnough: isEnoughMoney,
+      }, { step: 'sync-balance' })
     }
 
     getRefundTxHex = () => {

--- a/src/swap.flows/ETHTOKEN2BTC.js
+++ b/src/swap.flows/ETHTOKEN2BTC.js
@@ -79,11 +79,11 @@ export default (tokenName) => {
       super._persistSteps()
       this._persistState()
     }
-    
+
     _persistState() {
       super._persistState()
     }
-    
+
     _getSteps() {
       const flow = this
 
@@ -152,22 +152,22 @@ export default (tokenName) => {
           }
 
           const allowance = await flow.ethTokenSwap.checkAllowance(SwapApp.services.auth.getPublicData().eth.address)
-          
+
           if (allowance < sellAmount) {
             await flow.ethTokenSwap.approve({
               amount: sellAmount,
             })
           }
-          
+
           /* create contract and save this hash */
           let ethSwapCreationTransactionHash
           await flow.ethTokenSwap.create(swapData, async (hash) => {
             ethSwapCreationTransactionHash = hash;
           });
-          
+
           /* set Target wallet */
           //await flow.setTargetWalletDo();
-          
+
           /* send data to other side */
           flow.swap.room.sendMessage({
             event: 'create eth contract',
@@ -175,11 +175,11 @@ export default (tokenName) => {
               ethSwapCreationTransactionHash: ethSwapCreationTransactionHash,
             },
           })
-          
+
           flow.setState({
             ethSwapCreationTransactionHash: ethSwapCreationTransactionHash,
           })
-          
+
           flow.finishStep({
             isEthContractFunded: true,
           }, {step: 'lock-eth'})
@@ -214,7 +214,7 @@ export default (tokenName) => {
           const { participant } = flow.swap
 
           const checkSecretExist = async () => {
-            try { 
+            try {
               const secret = await flow.ethTokenSwap.getSecret({
                 participantAddress: participant.eth.address,
               })
@@ -312,7 +312,7 @@ export default (tokenName) => {
         })
       } else {
         if (this.state.isSignFetching || this.state.isMeSigned) return true;
-        
+
         this.setState({
           isSignFetching: true,
         })
@@ -326,7 +326,7 @@ export default (tokenName) => {
         this.swap.room.sendMessage({
           event: 'swap sign',
         })
-        
+
         this.finishStep({
           isMeSigned: true,
         }, { step: 'sign', silentError: true })

--- a/src/swap.swap/Flow.js
+++ b/src/swap.swap/Flow.js
@@ -99,7 +99,6 @@ class Flow {
   _saveState() {
     SwapApp.env.storage.setItem(`flow.${this.swap.id}`, this.state)
   }
-
   finishStep(data, constraints) {
     console.log(`on step ${this.state.step}, constraints =`, constraints)
 

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -107,17 +107,17 @@ class Swap {
 
     SwapApp.env.storage.setItem(`swap.${this.id}`, data)
   }
-  
+
   setDestinationBuyAddress(address) {
     this.destinationBuyAddress = address;
     this._saveState();
   }
-  
+
   setDestinationSellAddress(address) {
     this.destinationSellAddress = address;
     this._saveState();
   }
-  
+
   update(values) {
     Object.keys(values).forEach((key) => {
       if (key === 'buyAmount' || key === 'sellAmount') {

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -6,16 +6,18 @@ import Room from './Room'
 class Swap {
 
   constructor(id, order) {
-    this.id               = null
-    this.isMy             = null
-    this.owner            = null
-    this.participant      = null
-    this.buyCurrency      = null
-    this.sellCurrency     = null
-    this.buyAmount        = null
-    this.sellAmount       = null
-    this.ownerSwap        = null
-    this.participantSwap  = null
+    this.id                     = null
+    this.isMy                   = null
+    this.owner                  = null
+    this.participant            = null
+    this.buyCurrency            = null
+    this.sellCurrency           = null
+    this.buyAmount              = null
+    this.sellAmount             = null
+    this.ownerSwap              = null
+    this.participantSwap        = null
+    this.destinationBuyAddress  = null
+    this.destinationSellAddress = null
 
     let data = SwapApp.env.storage.getItem(`swap.${id}`)
 
@@ -60,9 +62,11 @@ class Swap {
       'sellCurrency',
       'buyAmount',
       'sellAmount',
+      'destinationBuyAddress',
+      'destinationSellAddress',
     )
 
-    const { isMy, buyCurrency, sellCurrency, buyAmount, sellAmount, ...rest } = data
+    const { isMy, buyCurrency, sellCurrency, buyAmount, sellAmount, destinationBuyAddress, destinationSellAddress, ...rest } = data
 
     const swap = {
       ...rest,
@@ -71,6 +75,8 @@ class Swap {
       sellCurrency: isMy ? sellCurrency : buyCurrency,
       buyAmount: isMy ? buyAmount : sellAmount,
       sellAmount: isMy ? sellAmount : buyAmount,
+      destinationBuyAddress: destinationBuyAddress,
+      destinationSellAddress: destinationSellAddress
     }
 
     if (!swap.participant && !isMy) {
@@ -91,6 +97,8 @@ class Swap {
       'sellCurrency',
       'buyAmount',
       'sellAmount',
+      'destinationBuyAddress',
+      'destinationSellAddress',
     )
   }
 
@@ -99,7 +107,17 @@ class Swap {
 
     SwapApp.env.storage.setItem(`swap.${this.id}`, data)
   }
-
+  
+  setDestinationBuyAddress(address) {
+    this.destinationBuyAddress = address;
+    this._saveState();
+  }
+  
+  setDestinationSellAddress(address) {
+    this.destinationSellAddress = address;
+    this._saveState();
+  }
+  
   update(values) {
     Object.keys(values).forEach((key) => {
       if (key === 'buyAmount' || key === 'sellAmount') {

--- a/src/swap.swaps/BtcSwap.js
+++ b/src/swap.swaps/BtcSwap.js
@@ -40,6 +40,15 @@ class BtcSwap extends SwapInterface {
 
   /**
    *
+   * @param {boolean} satoshis
+   * @returns {BigNumber|double}
+   * @public
+   */
+  getTxFee( satoshis ) {
+    return (satoshis) ? this.feeValue : this.feeValue / 100000000
+  }
+  /**
+   *
    * @param {object} data
    * @param {object} data.script
    * @param {*} data.txRaw
@@ -144,7 +153,59 @@ class BtcSwap extends SwapInterface {
       return `Expected script recipient publicKey: ${expected.recipientPublicKey}, got: ${recipientPublicKey}`
     }
   }
+  /**
+   *
+   * @param {object} data
+   * @param {object} data.scriptValues
+   * @param {BigNumber} data.amount
+   * @param {function} handleTransactionHash
+   * @returns {Promise}
+   */
+  fundExistScript(data, handleTransactionHash) {
+    const { scriptAddress, amount } = data
 
+    return new Promise(async (resolve, reject) => {
+      try {
+        
+        const tx            = new SwapApp.env.bitcoin.TransactionBuilder(this.network)
+        const unspents      = await this.fetchUnspents(SwapApp.services.auth.accounts.btc.getAddress())
+
+        const fundValue     = amount.multipliedBy(1e8).integerValue().toNumber()
+        const feeValue      = this.getTxFee( true ) // TODO how to get this value
+        const totalUnspent  = unspents.reduce((summ, { satoshis }) => summ + satoshis, 0)
+        const skipValue     = totalUnspent - fundValue - feeValue
+
+        if (totalUnspent < feeValue + fundValue) {
+          throw new Error(`Total less than fee: ${totalUnspent} < ${feeValue} + ${fundValue}`)
+        }
+
+        unspents.forEach(({ txid, vout }) => tx.addInput(txid, vout))
+        tx.addOutput(scriptAddress, fundValue)
+        tx.addOutput(SwapApp.services.auth.accounts.btc.getAddress(), skipValue)
+        tx.inputs.forEach((input, index) => {
+          tx.sign(index, SwapApp.services.auth.accounts.btc)
+        })
+
+        const txRaw = tx.buildIncomplete()
+
+        if (typeof handleTransactionHash === 'function') {
+          handleTransactionHash(txRaw.getId())
+        }
+
+        try {
+          const result = await this.broadcastTx(txRaw.toHex())
+
+          resolve(result)
+        }
+        catch (err) {
+          reject(err)
+        }
+      }
+      catch (err) {
+        reject(err)
+      }
+    })
+  }
   /**
    *
    * @param {object} data
@@ -164,7 +225,7 @@ class BtcSwap extends SwapInterface {
         const unspents      = await this.fetchUnspents(SwapApp.services.auth.accounts.btc.getAddress())
 
         const fundValue     = amount.multipliedBy(1e8).integerValue().toNumber()
-        const feeValue      = this.feeValue // TODO how to get this value
+        const feeValue      = this.getTxFee( true ) // TODO how to get this value
         const totalUnspent  = unspents.reduce((summ, { satoshis }) => summ + satoshis, 0)
         const skipValue     = totalUnspent - fundValue - feeValue
 

--- a/src/swap.swaps/BtcSwap.js
+++ b/src/swap.swaps/BtcSwap.js
@@ -153,7 +153,7 @@ class BtcSwap extends SwapInterface {
       return `Expected script recipient publicKey: ${expected.recipientPublicKey}, got: ${recipientPublicKey}`
     }
   }
-  
+
   /**
    *
    * @param {object} data

--- a/src/swap.swaps/EthTokenSwap.js
+++ b/src/swap.swaps/EthTokenSwap.js
@@ -153,10 +153,10 @@ class EthTokenSwap extends SwapInterface {
 
     return new Promise(async (resolve, reject) => {
       const hash    = `0x${secretHash.replace(/^0x/, '')}`
-      
+
       const values  = (targetWallet && (targetWallet!==participantAddress)) ?
         [ hash , participantAddress, targetWallet , newAmount, this.tokenAddress ]
-        : 
+        :
         [ hash, participantAddress, newAmount, this.tokenAddress ]
 
       const params  = {
@@ -164,9 +164,9 @@ class EthTokenSwap extends SwapInterface {
         gas: this.gasLimit,
         gasPrice: this.gasPrice,
       }
-      
+
       const contractMethod = (targetWallet && (targetWallet!==participantAddress)) ? 'createSwapTarget' : 'createSwap'
-      
+
       try {
         console.log("Get gas fee");
         const gasFee = await this.contract.methods[contractMethod](...values).estimateGas(params)
@@ -289,7 +289,7 @@ class EthTokenSwap extends SwapInterface {
    * @param {function} handleTransactionHash
    */
   async setTargetWallet(participantAddress, newTargetWallet, handleTransactionHash) {
-    // --- 
+    // ---
   }
   async getTargetWallet(ownerAddress) {
     console.log('EthTokenSwap->getTargetWallet');
@@ -299,7 +299,7 @@ class EthTokenSwap extends SwapInterface {
           from: SwapApp.services.auth.accounts.eth.address,
         })
         console.log('EthTokenSwap->getTargetWallet',targetWallet);
-        
+
         resolve(targetWallet)
       }
       catch (err) {


### PR DESCRIPTION
Flow BTC2ETHTOKEN has allowFundBTCDirectly (default false) - set it true to allow fund btc script directry
flow.state.scriptData has script params (and address)
checkScriptBalance - call for update script balance and continue swap
.....

У флоу BTC2ETHTOKEN есть свойство allowFundBTCDirectly (по умолчанию выключено)
Если стоит true, то при обмене на шаге 3 при проверке баланса не возвращает ошибку, а переходит на шаг 4
В шаге 4, если есть деньги на счету - старая логика, если нет, то создает скрипт - его параметры (и адрес) сохраняет в flow.state.scriptData
На стороне front-end (где используется кор) в шаге 4 проверяем баланс, если его не достаточно, проверяем наличие скрипта и его адреса (flow.scriptData && flow.scriptData.scriptAddress). Просим пользователя пополнить ( flow.scriptData.scriptAddress ).
Проверяем баланс скрипта ( flow.checkScriptBalance() )