### PR TITLE
buy+sell address in order data

### DIFF
--- a/src/swap.orders/Order.js
+++ b/src/swap.orders/Order.js
@@ -36,7 +36,9 @@ class Order {
     this.isRequested      = false // outcome request status
     this.isProcessing     = false // if swap isProcessing
     this.isPartialClosure = false
-
+    this.destinationBuyAddress = null // (!my Buy==Sell)
+    this.destinationSellAddress = null// (!my Sell==Buy)
+    
     this._update({
       ...data,
       isMy: data.owner.peer === SwapApp.services.room.peer,

--- a/src/swap.orders/SwapOrders.js
+++ b/src/swap.orders/SwapOrders.js
@@ -36,6 +36,8 @@ const checkIncomeOrderFormat = (order) => {
     isProcessing: '?Boolean',
     isRequested: '?Boolean',
     isPartialClosure: '?Boolean',
+    destinationBuyAddress: util.typeforce.t.maybe('String'),
+    destinationSellAddress: util.typeforce.t.maybe('String'),
   }
 
   const isValid = util.typeforce.check(format, order, true)
@@ -101,6 +103,8 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
         'isRequested',
         'isProcessing',
         'isPartialClosure',
+        'destinationBuyAddress',
+        'destinationSellAddress',
       ))
 
       SwapApp.services.room.sendMessagePeer(peer,
@@ -251,6 +255,8 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
       'isRequested',
       'isProcessing',
       'isPartialClosure',
+      'destinationBuyAddress',
+      'destinationSellAddress',
     ))
 
     SwapApp.env.storage.setItem('myOrders', myOrders)
@@ -293,7 +299,9 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
           'sellAmount',
           'isRequested',
           'isProcessing',
-          'isPartialClosure'
+          'isPartialClosure',
+          'destinationBuyAddress',
+          'destinationSellAddress'
         ),
       },
     })

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -75,8 +75,8 @@ class Swap {
       sellCurrency: isMy ? sellCurrency : buyCurrency,
       buyAmount: isMy ? buyAmount : sellAmount,
       sellAmount: isMy ? sellAmount : buyAmount,
-      destinationBuyAddress: destinationBuyAddress,
-      destinationSellAddress: destinationSellAddress
+      destinationBuyAddress: isMy ? destinationBuyAddress : destinationSellAddress,
+      destinationSellAddress: isMy ? destinationSellAddress : destinationBuyAddress
     }
 
     if (!swap.participant && !isMy) {

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -48,18 +48,18 @@ class Swap {
 
     this.flow = new Flow(this)
 
-    const swap = this;
-
     // Change destination address on run time
-    this.room.on('set destination buy address', function (data) {
+    this.room.on('set destination buy address', (data) => {
       console.log("Other side change destination buy address", data);
-      swap.destinationSellAddress = data.address;
-      swap._saveState();
+      this.update({
+        destinationSellAddress: data.address
+      })
     });
-    this.room.on('set destination sell address', function (data) {
+    this.room.on('set destination sell address', (data) => {
       console.log("Other side change destination sell address", data);
-      swap.destinationBuyAddress = data.address;
-      swap._saveState();
+      this.update({
+        destinationBuyAddress: data.address
+      })
     });
   }
 

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -123,8 +123,10 @@ class Swap {
   }
 
   setDestinationBuyAddress(address) {
-    this.destinationBuyAddress = address;
-    this._saveState();
+    this.update({
+      destinationBuyAddress: address
+    });
+
     this.room.sendMessage({
       event: 'set destination buy address',
       data: {
@@ -134,8 +136,10 @@ class Swap {
   }
 
   setDestinationSellAddress(address) {
-    this.destinationSellAddress = address;
-    this._saveState();
+    this.update({
+      destinationSellAddress: address
+    });
+
     this.room.sendMessage({
       event: 'set destination sell address',
       data: {

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -47,6 +47,20 @@ class Swap {
     }
 
     this.flow = new Flow(this)
+
+    const swap = this;
+
+    // Change destination address on run time
+    this.room.on('set destination buy address', function (data) {
+      console.log("Other side change destination buy address", data);
+      swap.destinationSellAddress = data.address;
+      swap._saveState();
+    });
+    this.room.on('set destination sell address', function (data) {
+      console.log("Other side change destination sell address", data);
+      swap.destinationBuyAddress = data.address;
+      swap._saveState();
+    });
   }
 
   _getDataFromOrder(order) {
@@ -111,11 +125,23 @@ class Swap {
   setDestinationBuyAddress(address) {
     this.destinationBuyAddress = address;
     this._saveState();
+    this.room.sendMessage({
+      event: 'set destination buy address',
+      data: {
+        address: address
+      }
+    });
   }
 
   setDestinationSellAddress(address) {
     this.destinationSellAddress = address;
     this._saveState();
+    this.room.sendMessage({
+      event: 'set destination sell address',
+      data: {
+        address: address
+      }
+    });
   }
 
   update(values) {


### PR DESCRIPTION
Маленькое дополнение к адресам покупки/продажи
Опционально эти адреса можно указать при создании ордера (destinationBuyAddress/destinationSellAddress)
Автоматом передает эти поля в своп по правилу (isMy)

В testnet.swap.online не проходит проверку из-за не описаных полей buy/sell в ордере

![image](https://user-images.githubusercontent.com/1880211/48429575-8cdd2980-e77e-11e8-86eb-b399af98595c.png)
![image](https://user-images.githubusercontent.com/1880211/48429908-21478c00-e77f-11e8-868c-87f03fdb6202.png)
![image](https://user-images.githubusercontent.com/1880211/48429999-57850b80-e77f-11e8-9399-a36f4d871e8c.png)
