### PR TITLE
debug: group console.log by modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-runtime": "^6.26.0",
     "bignumber.js": "^7.2.1",
     "bitcoinjs-lib": "^3.3.2",
+    "debug": "^4.1.0",
     "eosjs": "^15.0.3",
     "ethereum-input-data-decoder": "0.0.12",
     "node-gyp": "^3.8.0",

--- a/src/swap.app/Events.js
+++ b/src/swap.app/Events.js
@@ -110,7 +110,7 @@ class EventAggregator {
     const event = this.getEvent(name)
 
     if (event) {
-      debug('swap:events')('dispatch event', name)
+      debug('swap.core:events')('dispatch event', name)
       event.call(...eventArgs)
     }
   }

--- a/src/swap.app/Events.js
+++ b/src/swap.app/Events.js
@@ -1,3 +1,5 @@
+import debug from 'debug'
+
 class Event {
 
   /**
@@ -108,7 +110,7 @@ class EventAggregator {
     const event = this.getEvent(name)
 
     if (event) {
-      console.log('event', name)
+      debug('swap:events')('dispatch event', name)
       event.call(...eventArgs)
     }
   }

--- a/src/swap.flows/BTC2ETH.js
+++ b/src/swap.flows/BTC2ETH.js
@@ -79,13 +79,6 @@ class BTC2ETH extends Flow {
 
   _persistState() {
     super._persistState()
-
-    // this.ethSwap.getBalance({
-    //   ownerAddress: this.swap.participant.eth.address,
-    // })
-    //   .then((balance) => {
-    //     console.log('balance:', balance)
-    //   })
   }
 
   _getSteps() {

--- a/src/swap.flows/BTC2ETHTOKEN.js
+++ b/src/swap.flows/BTC2ETHTOKEN.js
@@ -372,7 +372,7 @@ export default (tokenName) => {
     }
     createWorkBTCScript(secretHash) {
       if (this.state.btcScriptValues) {
-        debug('swap:flow')('BTC Script already generated', this.state.btcScriptValues);
+        debug('swap.core:flow')('BTC Script already generated', this.state.btcScriptValues);
         return;
       }
       const { participant } = this.swap
@@ -397,7 +397,7 @@ export default (tokenName) => {
     }
 
     async checkScriptBalance() {
-      debug('swap:flow')("BTC2ETHTOKEN checkScriptBalance - nothing do - empty :p - wait infinity loop");
+      debug('swap.core:flow')("BTC2ETHTOKEN checkScriptBalance - nothing do - empty :p - wait infinity loop");
     }
 
     async syncBalance() {

--- a/src/swap.flows/BTC2ETHTOKEN.js
+++ b/src/swap.flows/BTC2ETHTOKEN.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto'
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -371,7 +372,7 @@ export default (tokenName) => {
     }
     createWorkBTCScript(secretHash) {
       if (this.state.btcScriptValues) {
-        console.log('BTC Script already generated',this.state.btcScriptValues);
+        debug('swap:flow')('BTC Script already generated', this.state.btcScriptValues);
         return;
       }
       const { participant } = this.swap
@@ -396,7 +397,7 @@ export default (tokenName) => {
     }
 
     async checkScriptBalance() {
-      console.log("BTC2ETHTOKEN checkScriptBalance - nothing do - empty :p - wait infinity loop");
+      debug('swap:flow')("BTC2ETHTOKEN checkScriptBalance - nothing do - empty :p - wait infinity loop");
     }
 
     async syncBalance() {

--- a/src/swap.flows/BTC2LTC.js
+++ b/src/swap.flows/BTC2LTC.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto'
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -86,7 +87,7 @@ class BTC2LTC extends Flow {
     //   ownerAddress: this.swap.participant.ltc.address,
     // })
     //   .then((balance) => {
-    //     console.log('balance:', balance)
+    //     debug('swap:flow')('balance:', balance)
     //   })
   }
 
@@ -208,7 +209,7 @@ class BTC2LTC extends Flow {
             const { scriptAddress } = this.ltcSwap.createScript(flow.state.ltcScriptValues)
             const balance = await flow.ltcSwap.getBalance(scriptAddress)
 
-            console.log('Litecoin balance - ' + balance)
+            debug('swap:flow')('Litecoin balance - ' + balance)
 
             if (balance > 0) {
               if (!flow.state.isLtcScriptFunded) { // redundant condition but who cares :D

--- a/src/swap.flows/BTC2LTC.js
+++ b/src/swap.flows/BTC2LTC.js
@@ -87,7 +87,7 @@ class BTC2LTC extends Flow {
     //   ownerAddress: this.swap.participant.ltc.address,
     // })
     //   .then((balance) => {
-    //     debug('swap:flow')('balance:', balance)
+    //     debug('swap.core:flow')('balance:', balance)
     //   })
   }
 
@@ -209,7 +209,7 @@ class BTC2LTC extends Flow {
             const { scriptAddress } = this.ltcSwap.createScript(flow.state.ltcScriptValues)
             const balance = await flow.ltcSwap.getBalance(scriptAddress)
 
-            debug('swap:flow')('Litecoin balance - ' + balance)
+            debug('swap.core:flow')('Litecoin balance - ' + balance)
 
             if (balance > 0) {
               if (!flow.state.isLtcScriptFunded) { // redundant condition but who cares :D

--- a/src/swap.flows/EOS2BTC.js
+++ b/src/swap.flows/EOS2BTC.js
@@ -23,7 +23,7 @@ const handlers = (flow) => {
 
       return tryWithdraw()
         .catch((error) => {
-          debug('swap:flow')('Cannot withdraw BTC, try again in 5 sec...')
+          debug('swap.core:flow')('Cannot withdraw BTC, try again in 5 sec...')
           return sleep(5000).then(tryWithdraw)
         })
     },
@@ -66,7 +66,7 @@ const listeners = (flow) => {
         })
 
         if (scriptCheckResult) {
-          debug('swap:flow')('Cannot verify btc script', scriptCheckResult)
+          debug('swap.core:flow')('Cannot verify btc script', scriptCheckResult)
           reject(scriptCheckResult)
         } else {
           resolve()
@@ -88,7 +88,7 @@ const listeners = (flow) => {
 
         return fetchSecret().then((secret) => {
           if (secret == 0) {
-            debug('swap:flow')('Cannot fetch secret, try again in 5 sec...')
+            debug('swap.core:flow')('Cannot fetch secret, try again in 5 sec...')
             return sleep(5000).then(fetchSecret)
           } else {
             return secret

--- a/src/swap.flows/EOS2BTC.js
+++ b/src/swap.flows/EOS2BTC.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
 
@@ -22,7 +23,7 @@ const handlers = (flow) => {
 
       return tryWithdraw()
         .catch((error) => {
-          console.log('Cannot withdraw BTC, try again in 5 sec...')
+          debug('swap:flow')('Cannot withdraw BTC, try again in 5 sec...')
           return sleep(5000).then(tryWithdraw)
         })
     },
@@ -65,7 +66,7 @@ const listeners = (flow) => {
         })
 
         if (scriptCheckResult) {
-          console.log('Cannot verify btc script', scriptCheckResult)
+          debug('swap:flow')('Cannot verify btc script', scriptCheckResult)
           reject(scriptCheckResult)
         } else {
           resolve()
@@ -87,7 +88,7 @@ const listeners = (flow) => {
 
         return fetchSecret().then((secret) => {
           if (secret == 0) {
-            console.log('Cannot fetch secret, try again in 5 sec...')
+            debug('swap:flow')('Cannot fetch secret, try again in 5 sec...')
             return sleep(5000).then(fetchSecret)
           } else {
             return secret

--- a/src/swap.flows/ETH2BTC.js
+++ b/src/swap.flows/ETH2BTC.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto' // move to BtcSwap
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -112,7 +113,7 @@ class ETH2BTC extends Flow {
       // 3. Verify BTC Script
 
       () => {
-        console.log(`waiting verify btc script`)
+        debug('swap:flow')(`waiting verify btc script`)
         // this.verifyBtcScript()
       },
 
@@ -172,7 +173,7 @@ class ETH2BTC extends Flow {
             return console.error(err)
         }
 
-        console.log(`finish step`)
+        debug('swap:flow')(`finish step`)
 
         flow.finishStep({
           isEthContractFunded: true,
@@ -190,7 +191,7 @@ class ETH2BTC extends Flow {
           const secret = await flow.ethSwap.getSecretFromTxhash(ethSwapWithdrawTransactionHash)
 
           if (!flow.state.isEthWithdrawn && secret) {
-            console.log('got secret from tx', ethSwapWithdrawTransactionHash, secret)
+            debug('swap:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
             flow.finishStep({
               isEthWithdrawn: true,
               secret,
@@ -220,7 +221,7 @@ class ETH2BTC extends Flow {
                 throw new Error(`Secret already exists and it differs! ${secret} ≠ ${flow.state.secret}`)
               }
 
-              console.log('got secret from smart contract', secret)
+              debug('swap:flow')('got secret from smart contract', secret)
               flow.finishStep({
                 secret,
                 isEthWithdrawn: true,
@@ -257,7 +258,7 @@ class ETH2BTC extends Flow {
           })
         })
 
-        
+
 
         flow.finishStep({
           isBtcWithdrawn: true,
@@ -406,7 +407,7 @@ class ETH2BTC extends Flow {
     if (isBtcWithdrawn)
       console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-    console.log(`WITHDRAW using secret = ${_secret}`)
+    debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
 
     const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
     if (secretHash != _secretHash)
@@ -415,7 +416,7 @@ class ETH2BTC extends Flow {
     const { scriptAddress } = this.btcSwap.createScript(btcScriptValues)
     const balance = await this.btcSwap.getBalance(scriptAddress)
 
-    console.log(`address=${scriptAddress}, balance=${balance}`)
+    debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
 
     if (balance === 0) {
       this.finishStep({
@@ -428,12 +429,12 @@ class ETH2BTC extends Flow {
       scriptValues: btcScriptValues,
       secret: _secret,
     }, (hash) => {
-      console.log(`TX hash=${hash}`)
+      debug('swap:flow')(`TX hash=${hash}`)
       this.setState({
         btcSwapWithdrawTransactionHash: hash,
       })
     })
-    console.log(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
+    debug('swap:flow')(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
 
     this.finishStep({
       isBtcWithdrawn: true,

--- a/src/swap.flows/ETH2BTC.js
+++ b/src/swap.flows/ETH2BTC.js
@@ -113,7 +113,7 @@ class ETH2BTC extends Flow {
       // 3. Verify BTC Script
 
       () => {
-        debug('swap:flow')(`waiting verify btc script`)
+        debug('swap.core:flow')(`waiting verify btc script`)
         // this.verifyBtcScript()
       },
 
@@ -173,7 +173,7 @@ class ETH2BTC extends Flow {
             return console.error(err)
         }
 
-        debug('swap:flow')(`finish step`)
+        debug('swap.core:flow')(`finish step`)
 
         flow.finishStep({
           isEthContractFunded: true,
@@ -191,7 +191,7 @@ class ETH2BTC extends Flow {
           const secret = await flow.ethSwap.getSecretFromTxhash(ethSwapWithdrawTransactionHash)
 
           if (!flow.state.isEthWithdrawn && secret) {
-            debug('swap:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
+            debug('swap.core:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
             flow.finishStep({
               isEthWithdrawn: true,
               secret,
@@ -221,7 +221,7 @@ class ETH2BTC extends Flow {
                 throw new Error(`Secret already exists and it differs! ${secret} ≠ ${flow.state.secret}`)
               }
 
-              debug('swap:flow')('got secret from smart contract', secret)
+              debug('swap.core:flow')('got secret from smart contract', secret)
               flow.finishStep({
                 secret,
                 isEthWithdrawn: true,
@@ -407,7 +407,7 @@ class ETH2BTC extends Flow {
     if (isBtcWithdrawn)
       console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-    debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
+    debug('swap.core:flow')(`WITHDRAW using secret = ${_secret}`)
 
     const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
     if (secretHash != _secretHash)
@@ -416,7 +416,7 @@ class ETH2BTC extends Flow {
     const { scriptAddress } = this.btcSwap.createScript(btcScriptValues)
     const balance = await this.btcSwap.getBalance(scriptAddress)
 
-    debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
+    debug('swap.core:flow')(`address=${scriptAddress}, balance=${balance}`)
 
     if (balance === 0) {
       this.finishStep({
@@ -429,12 +429,12 @@ class ETH2BTC extends Flow {
       scriptValues: btcScriptValues,
       secret: _secret,
     }, (hash) => {
-      debug('swap:flow')(`TX hash=${hash}`)
+      debug('swap.core:flow')(`TX hash=${hash}`)
       this.setState({
         btcSwapWithdrawTransactionHash: hash,
       })
     })
-    debug('swap:flow')(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
+    debug('swap.core:flow')(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
 
     this.finishStep({
       isBtcWithdrawn: true,

--- a/src/swap.flows/ETH2LTC.js
+++ b/src/swap.flows/ETH2LTC.js
@@ -113,7 +113,7 @@ class ETH2LTC extends Flow {
       // 3. Verify LTC Script
 
       () => {
-        debug('swap:flow')(`waiting verify ltc script`)
+        debug('swap.core:flow')(`waiting verify ltc script`)
         // this.verifyLtcScript()
       },
 
@@ -173,7 +173,7 @@ class ETH2LTC extends Flow {
             return console.error(err)
         }
 
-        debug('swap:flow')(`finish step`)
+        debug('swap.core:flow')(`finish step`)
 
         flow.finishStep({
           isEthContractFunded: true,
@@ -365,7 +365,7 @@ class ETH2LTC extends Flow {
     if (isLtcWithdrawn)
       console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-    debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
+    debug('swap.core:flow')(`WITHDRAW using secret = ${_secret}`)
 
     const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
     if (secretHash != _secretHash)
@@ -374,7 +374,7 @@ class ETH2LTC extends Flow {
     const { scriptAddress } = this.ltcSwap.createScript(ltcScriptValues)
     const balance = await this.ltcSwap.getBalance(scriptAddress)
 
-    debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
+    debug('swap.core:flow')(`address=${scriptAddress}, balance=${balance}`)
 
     if (balance === 0) {
       this.finishStep({
@@ -387,12 +387,12 @@ class ETH2LTC extends Flow {
       scriptValues: ltcScriptValues,
       secret: _secret,
     }, (hash) => {
-      debug('swap:flow')(`TX hash=${hash}`)
+      debug('swap.core:flow')(`TX hash=${hash}`)
       this.setState({
         ltcSwapWithdrawTransactionHash: hash,
       })
     })
-    debug('swap:flow')(`TX withdraw sent: ${this.state.ltcSwapWithdrawTransactionHash}`)
+    debug('swap.core:flow')(`TX withdraw sent: ${this.state.ltcSwapWithdrawTransactionHash}`)
 
     this.finishStep({
       isLtcWithdrawn: true,

--- a/src/swap.flows/ETH2LTC.js
+++ b/src/swap.flows/ETH2LTC.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto' // move to LtcSwap
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -112,7 +113,7 @@ class ETH2LTC extends Flow {
       // 3. Verify LTC Script
 
       () => {
-        console.log(`waiting verify ltc script`)
+        debug('swap:flow')(`waiting verify ltc script`)
         // this.verifyLtcScript()
       },
 
@@ -172,7 +173,7 @@ class ETH2LTC extends Flow {
             return console.error(err)
         }
 
-        console.log(`finish step`)
+        debug('swap:flow')(`finish step`)
 
         flow.finishStep({
           isEthContractFunded: true,
@@ -364,7 +365,7 @@ class ETH2LTC extends Flow {
     if (isLtcWithdrawn)
       console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-    console.log(`WITHDRAW using secret = ${_secret}`)
+    debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
 
     const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
     if (secretHash != _secretHash)
@@ -373,7 +374,7 @@ class ETH2LTC extends Flow {
     const { scriptAddress } = this.ltcSwap.createScript(ltcScriptValues)
     const balance = await this.ltcSwap.getBalance(scriptAddress)
 
-    console.log(`address=${scriptAddress}, balance=${balance}`)
+    debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
 
     if (balance === 0) {
       this.finishStep({
@@ -386,12 +387,12 @@ class ETH2LTC extends Flow {
       scriptValues: ltcScriptValues,
       secret: _secret,
     }, (hash) => {
-      console.log(`TX hash=${hash}`)
+      debug('swap:flow')(`TX hash=${hash}`)
       this.setState({
         ltcSwapWithdrawTransactionHash: hash,
       })
     })
-    console.log(`TX withdraw sent: ${this.state.ltcSwapWithdrawTransactionHash}`)
+    debug('swap:flow')(`TX withdraw sent: ${this.state.ltcSwapWithdrawTransactionHash}`)
 
     this.finishStep({
       isLtcWithdrawn: true,

--- a/src/swap.flows/ETHTOKEN2BTC.js
+++ b/src/swap.flows/ETHTOKEN2BTC.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto' // move to BtcSwap
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -196,7 +197,7 @@ export default (tokenName) => {
             const secret = await flow.ethTokenSwap.getSecretFromTxhash(ethSwapWithdrawTransactionHash)
 
             if (!flow.state.isEthWithdrawn && secret) {
-              console.log('got secret from tx', ethSwapWithdrawTransactionHash, secret)
+              debug('swap:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
               flow.finishStep({
                 isEthWithdrawn: true,
                 secret,
@@ -226,7 +227,7 @@ export default (tokenName) => {
                   throw new Error(`Secret already exists and it differs! ${secret} ≠ ${flow.state.secret}`)
                 }
 
-                console.log('got secret from smart contract', secret)
+                debug('swap:flow')('got secret from smart contract', secret)
                 flow.finishStep({
                   secret,
                   isEthWithdrawn: true,
@@ -412,7 +413,7 @@ export default (tokenName) => {
       if (isBtcWithdrawn)
         console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-      console.log(`WITHDRAW using secret = ${_secret}`)
+      debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
 
       const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
 
@@ -422,7 +423,7 @@ export default (tokenName) => {
       const {scriptAddress} = this.btcSwap.createScript(btcScriptValues)
       const balance = await this.btcSwap.getBalance(scriptAddress)
 
-      console.log(`address=${scriptAddress}, balance=${balance}`)
+      debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
 
       if (balance === 0) {
         this.finishStep({

--- a/src/swap.flows/ETHTOKEN2BTC.js
+++ b/src/swap.flows/ETHTOKEN2BTC.js
@@ -152,20 +152,27 @@ export default (tokenName) => {
             targetWallet: flow.swap.destinationSellAddress
           }
 
+          debug('swap:flow')('fetching allowance')
           const allowance = await flow.ethTokenSwap.checkAllowance(SwapApp.services.auth.getPublicData().eth.address)
+          debug('swap:flow')('allowance', allowance)
 
           if (allowance < sellAmount) {
+            debug('swap:flow')('allowance < sellAmount', allowance, sellAmount)
             await flow.ethTokenSwap.approve({
               amount: sellAmount,
             })
           }
 
+
+          debug('swap:flow')('create swap', swapData)
           /* create contract and save this hash */
           let ethSwapCreationTransactionHash
           await flow.ethTokenSwap.create(swapData, async (hash) => {
+            debug('swap:flow')('create swap tx hash', hash)
             ethSwapCreationTransactionHash = hash;
           });
 
+          debug('swap:flow')('created swap!', ethSwapCreationTransactionHash)
           /* set Target wallet */
           //await flow.setTargetWalletDo();
 

--- a/src/swap.flows/ETHTOKEN2BTC.js
+++ b/src/swap.flows/ETHTOKEN2BTC.js
@@ -152,27 +152,27 @@ export default (tokenName) => {
             targetWallet: flow.swap.destinationSellAddress
           }
 
-          debug('swap:flow')('fetching allowance')
+          debug('swap.core:flow')('fetching allowance')
           const allowance = await flow.ethTokenSwap.checkAllowance(SwapApp.services.auth.getPublicData().eth.address)
-          debug('swap:flow')('allowance', allowance)
+          debug('swap.core:flow')('allowance', allowance)
 
           if (allowance < sellAmount) {
-            debug('swap:flow')('allowance < sellAmount', allowance, sellAmount)
+            debug('swap.core:flow')('allowance < sellAmount', allowance, sellAmount)
             await flow.ethTokenSwap.approve({
               amount: sellAmount,
             })
           }
 
 
-          debug('swap:flow')('create swap', swapData)
+          debug('swap.core:flow')('create swap', swapData)
           /* create contract and save this hash */
           let ethSwapCreationTransactionHash
           await flow.ethTokenSwap.create(swapData, async (hash) => {
-            debug('swap:flow')('create swap tx hash', hash)
+            debug('swap.core:flow')('create swap tx hash', hash)
             ethSwapCreationTransactionHash = hash;
           });
 
-          debug('swap:flow')('created swap!', ethSwapCreationTransactionHash)
+          debug('swap.core:flow')('created swap!', ethSwapCreationTransactionHash)
           /* set Target wallet */
           //await flow.setTargetWalletDo();
 
@@ -204,7 +204,7 @@ export default (tokenName) => {
             const secret = await flow.ethTokenSwap.getSecretFromTxhash(ethSwapWithdrawTransactionHash)
 
             if (!flow.state.isEthWithdrawn && secret) {
-              debug('swap:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
+              debug('swap.core:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
               flow.finishStep({
                 isEthWithdrawn: true,
                 secret,
@@ -234,7 +234,7 @@ export default (tokenName) => {
                   throw new Error(`Secret already exists and it differs! ${secret} ≠ ${flow.state.secret}`)
                 }
 
-                debug('swap:flow')('got secret from smart contract', secret)
+                debug('swap.core:flow')('got secret from smart contract', secret)
                 flow.finishStep({
                   secret,
                   isEthWithdrawn: true,
@@ -420,7 +420,7 @@ export default (tokenName) => {
       if (isBtcWithdrawn)
         console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-      debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
+      debug('swap.core:flow')(`WITHDRAW using secret = ${_secret}`)
 
       const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
 
@@ -430,7 +430,7 @@ export default (tokenName) => {
       const {scriptAddress} = this.btcSwap.createScript(btcScriptValues)
       const balance = await this.btcSwap.getBalance(scriptAddress)
 
-      debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
+      debug('swap.core:flow')(`address=${scriptAddress}, balance=${balance}`)
 
       if (balance === 0) {
         this.finishStep({

--- a/src/swap.flows/ETHTOKEN2USDT.js
+++ b/src/swap.flows/ETHTOKEN2USDT.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto' // move to BtcSwap
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -159,20 +160,20 @@ export default (tokenName) => {
             amount:               sellAmount,
           }
 
-          console.log('approve')
+          debug('swap:flow')('approve')
 
           await flow.ethTokenSwap.approve({
             amount: sellAmount,
           }, hash => {
-            console.log('approve tx hash', hash)
+            debug('swap:flow')('approve tx hash', hash)
           })
 
-          console.log('create swap')
+          debug('swap:flow')('create swap')
 
           await flow.ethTokenSwap.create(swapData, (hash) => {
             ethSwapCreationTransactionHash = hash
 
-            console.log('create swap tx hash', hash)
+            debug('swap:flow')('create swap tx hash', hash)
 
             flow.setState({
               ethSwapCreationTransactionHash: hash,
@@ -243,7 +244,7 @@ export default (tokenName) => {
               secret,
               amount: buyAmount,
             }, (hash) => {
-              console.log('withdraw tx hash', hash)
+              debug('swap:flow')('withdraw tx hash', hash)
 
               flow.setState({
                 usdtSwapWithdrawTransactionHash: hash,
@@ -384,7 +385,7 @@ export default (tokenName) => {
       if (isBtcWithdrawn)
         console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-      console.log(`WITHDRAW using secret = ${_secret}`)
+      debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
 
       const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
 
@@ -395,7 +396,7 @@ export default (tokenName) => {
 
       const balance = await this.usdtSwap.getBalance(scriptAddress)
 
-      console.log(`address=${scriptAddress}, balance=${balance}`)
+      debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
 
       if (balance === 0) {
         flow.finishStep({
@@ -409,13 +410,13 @@ export default (tokenName) => {
         scriptValues: usdtScriptValues,
         secret: _secret,
       }, (hash) => {
-        console.log(`TX hash=${hash}`)
+        debug('swap:flow')(`TX hash=${hash}`)
         this.setState({
           usdtSwapWithdrawTransactionHash: hash,
         })
       })
 
-      console.log(`TX withdraw sent: ${this.state.usdtSwapWithdrawTransactionHash}`)
+      debug('swap:flow')(`TX withdraw sent: ${this.state.usdtSwapWithdrawTransactionHash}`)
 
       this.finishStep({
         isBtcWithdrawn: true,
@@ -429,7 +430,7 @@ export default (tokenName) => {
       secret = 'c0809ce9f484fdcdfb2d5aabd609768ce0374ee97a1a5618ce4cd3f16c00a078'
 
       try {
-        console.log('TRYING REFUND!')
+        debug('swap:flow')('TRYING REFUND!')
 
         try {
           await this.ethTokenSwap.refund({
@@ -440,7 +441,7 @@ export default (tokenName) => {
             })
           })
 
-          console.log('SUCCESS REFUND!')
+          debug('swap:flow')('SUCCESS REFUND!')
           return
         }
         catch (err) {
@@ -465,7 +466,7 @@ export default (tokenName) => {
         }
       }
 
-      console.log('TRYING WITHDRAW!')
+      debug('swap:flow')('TRYING WITHDRAW!')
 
       try {
         await this.usdtSwap.withdraw({
@@ -477,7 +478,7 @@ export default (tokenName) => {
           })
         })
 
-        console.log('SUCCESS WITHDRAW!')
+        debug('swap:flow')('SUCCESS WITHDRAW!')
       }
       catch (err) {
         console.error('WITHDRAW FAILED!', err)

--- a/src/swap.flows/ETHTOKEN2USDT.js
+++ b/src/swap.flows/ETHTOKEN2USDT.js
@@ -160,20 +160,20 @@ export default (tokenName) => {
             amount:               sellAmount,
           }
 
-          debug('swap:flow')('approve')
+          debug('swap.core:flow')('approve')
 
           await flow.ethTokenSwap.approve({
             amount: sellAmount,
           }, hash => {
-            debug('swap:flow')('approve tx hash', hash)
+            debug('swap.core:flow')('approve tx hash', hash)
           })
 
-          debug('swap:flow')('create swap')
+          debug('swap.core:flow')('create swap')
 
           await flow.ethTokenSwap.create(swapData, (hash) => {
             ethSwapCreationTransactionHash = hash
 
-            debug('swap:flow')('create swap tx hash', hash)
+            debug('swap.core:flow')('create swap tx hash', hash)
 
             flow.setState({
               ethSwapCreationTransactionHash: hash,
@@ -244,7 +244,7 @@ export default (tokenName) => {
               secret,
               amount: buyAmount,
             }, (hash) => {
-              debug('swap:flow')('withdraw tx hash', hash)
+              debug('swap.core:flow')('withdraw tx hash', hash)
 
               flow.setState({
                 usdtSwapWithdrawTransactionHash: hash,
@@ -385,7 +385,7 @@ export default (tokenName) => {
       if (isBtcWithdrawn)
         console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-      debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
+      debug('swap.core:flow')(`WITHDRAW using secret = ${_secret}`)
 
       const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
 
@@ -396,7 +396,7 @@ export default (tokenName) => {
 
       const balance = await this.usdtSwap.getBalance(scriptAddress)
 
-      debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
+      debug('swap.core:flow')(`address=${scriptAddress}, balance=${balance}`)
 
       if (balance === 0) {
         flow.finishStep({
@@ -410,13 +410,13 @@ export default (tokenName) => {
         scriptValues: usdtScriptValues,
         secret: _secret,
       }, (hash) => {
-        debug('swap:flow')(`TX hash=${hash}`)
+        debug('swap.core:flow')(`TX hash=${hash}`)
         this.setState({
           usdtSwapWithdrawTransactionHash: hash,
         })
       })
 
-      debug('swap:flow')(`TX withdraw sent: ${this.state.usdtSwapWithdrawTransactionHash}`)
+      debug('swap.core:flow')(`TX withdraw sent: ${this.state.usdtSwapWithdrawTransactionHash}`)
 
       this.finishStep({
         isBtcWithdrawn: true,
@@ -430,7 +430,7 @@ export default (tokenName) => {
       secret = 'c0809ce9f484fdcdfb2d5aabd609768ce0374ee97a1a5618ce4cd3f16c00a078'
 
       try {
-        debug('swap:flow')('TRYING REFUND!')
+        debug('swap.core:flow')('TRYING REFUND!')
 
         try {
           await this.ethTokenSwap.refund({
@@ -441,7 +441,7 @@ export default (tokenName) => {
             })
           })
 
-          debug('swap:flow')('SUCCESS REFUND!')
+          debug('swap.core:flow')('SUCCESS REFUND!')
           return
         }
         catch (err) {
@@ -466,7 +466,7 @@ export default (tokenName) => {
         }
       }
 
-      debug('swap:flow')('TRYING WITHDRAW!')
+      debug('swap.core:flow')('TRYING WITHDRAW!')
 
       try {
         await this.usdtSwap.withdraw({
@@ -478,7 +478,7 @@ export default (tokenName) => {
           })
         })
 
-        debug('swap:flow')('SUCCESS WITHDRAW!')
+        debug('swap.core:flow')('SUCCESS WITHDRAW!')
       }
       catch (err) {
         console.error('WITHDRAW FAILED!', err)

--- a/src/swap.flows/LTC2BTC.js
+++ b/src/swap.flows/LTC2BTC.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto' // move to BtcSwap
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -113,7 +114,7 @@ class LTC2BTC extends Flow {
       // 3. Verify BTC Script
 
       () => {
-        console.log(`waiting verify btc script`)
+        debug('swap:flow')(`waiting verify btc script`)
         // this.verifyBtcScript()
       },
 
@@ -121,7 +122,7 @@ class LTC2BTC extends Flow {
 
       () => {
         this.syncBalance()
-        console.log(this)
+        debug('swap:flow')(this)
       },
 
       // 5. Create LTC Script
@@ -401,7 +402,7 @@ class LTC2BTC extends Flow {
     if (isBtcWithdrawn)
       console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-    console.log(`WITHDRAW using secret = ${_secret}`)
+    debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
 
     const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
     if (secretHash != _secretHash)
@@ -410,7 +411,7 @@ class LTC2BTC extends Flow {
     const { scriptAddress } = this.btcSwap.createScript(btcScriptValues)
     const balance = await this.btcSwap.getBalance(scriptAddress)
 
-    console.log(`address=${scriptAddress}, balance=${balance}`)
+    debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
 
     if (balance === 0) {
       this.finishStep({
@@ -423,12 +424,12 @@ class LTC2BTC extends Flow {
       scriptValues: btcScriptValues,
       secret: _secret,
     }, (hash) => {
-      console.log(`TX hash=${hash}`)
+      debug('swap:flow')(`TX hash=${hash}`)
       this.setState({
         btcSwapWithdrawTransactionHash: hash,
       })
     })
-    console.log(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
+    debug('swap:flow')(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
 
     this.finishStep({
       isBtcWithdrawn: true,

--- a/src/swap.flows/LTC2BTC.js
+++ b/src/swap.flows/LTC2BTC.js
@@ -114,7 +114,7 @@ class LTC2BTC extends Flow {
       // 3. Verify BTC Script
 
       () => {
-        debug('swap:flow')(`waiting verify btc script`)
+        debug('swap.core:flow')(`waiting verify btc script`)
         // this.verifyBtcScript()
       },
 
@@ -122,7 +122,7 @@ class LTC2BTC extends Flow {
 
       () => {
         this.syncBalance()
-        debug('swap:flow')(this)
+        debug('swap.core:flow')(this)
       },
 
       // 5. Create LTC Script
@@ -402,7 +402,7 @@ class LTC2BTC extends Flow {
     if (isBtcWithdrawn)
       console.warn(`Looks like money were already withdrawn, are you sure?`)
 
-    debug('swap:flow')(`WITHDRAW using secret = ${_secret}`)
+    debug('swap.core:flow')(`WITHDRAW using secret = ${_secret}`)
 
     const _secretHash = crypto.ripemd160(Buffer.from(_secret, 'hex')).toString('hex')
     if (secretHash != _secretHash)
@@ -411,7 +411,7 @@ class LTC2BTC extends Flow {
     const { scriptAddress } = this.btcSwap.createScript(btcScriptValues)
     const balance = await this.btcSwap.getBalance(scriptAddress)
 
-    debug('swap:flow')(`address=${scriptAddress}, balance=${balance}`)
+    debug('swap.core:flow')(`address=${scriptAddress}, balance=${balance}`)
 
     if (balance === 0) {
       this.finishStep({
@@ -424,12 +424,12 @@ class LTC2BTC extends Flow {
       scriptValues: btcScriptValues,
       secret: _secret,
     }, (hash) => {
-      debug('swap:flow')(`TX hash=${hash}`)
+      debug('swap.core:flow')(`TX hash=${hash}`)
       this.setState({
         btcSwapWithdrawTransactionHash: hash,
       })
     })
-    debug('swap:flow')(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
+    debug('swap.core:flow')(`TX withdraw sent: ${this.state.btcSwapWithdrawTransactionHash}`)
 
     this.finishStep({
       isBtcWithdrawn: true,

--- a/src/swap.flows/LTC2ETH.js
+++ b/src/swap.flows/LTC2ETH.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto'
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -84,7 +85,7 @@ class LTC2ETH extends Flow {
     //   ownerAddress: this.swap.participant.eth.address,
     // })
     //   .then((balance) => {
-    //     console.log('balance:', balance)
+    //     debug('swap:flow')('balance:', balance)
     //   })
   }
 

--- a/src/swap.flows/LTC2ETH.js
+++ b/src/swap.flows/LTC2ETH.js
@@ -85,7 +85,7 @@ class LTC2ETH extends Flow {
     //   ownerAddress: this.swap.participant.eth.address,
     // })
     //   .then((balance) => {
-    //     debug('swap:flow')('balance:', balance)
+    //     debug('swap.core:flow')('balance:', balance)
     //   })
   }
 

--- a/src/swap.flows/USDT2ETHTOKEN.js
+++ b/src/swap.flows/USDT2ETHTOKEN.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import crypto from 'bitcoinjs-lib/src/crypto'
 import SwapApp, { constants } from 'swap.app'
 import { Flow } from 'swap.swap'
@@ -94,14 +95,14 @@ export default (tokenName) => {
 
         () => {
           flow.swap.room.once('swap sign', () => {
-            console.log('swap sign!')
+            debug('swap:flow')('swap sign!')
             flow.finishStep({
               isParticipantSigned: true,
             }, { step: 'sign', silentError: true })
           })
 
           flow.swap.room.once('swap exists', () => {
-            console.log(`swap already exists`)
+            debug('swap:flow')(`swap already exists`)
           })
 
           // if I came late and he ALREADY send this, I request AGAIN
@@ -149,8 +150,8 @@ export default (tokenName) => {
             scriptValues = usdtScriptValues
           }
 
-          console.log('sellAmount', sellAmount)
-          console.log('scriptValues', scriptValues)
+          debug('swap:flow')('sellAmount', sellAmount)
+          debug('swap:flow')('scriptValues', scriptValues)
 
           let usdtFundingTransactionHash, usdtFunding
 
@@ -258,7 +259,7 @@ export default (tokenName) => {
 
           try {
             await flow.ethTokenSwap.withdraw(data, (hash) => {
-              console.log('withdraw tx hash', hash)
+              debug('swap:flow')('withdraw tx hash', hash)
 
               flow.setState({
                 ethSwapWithdrawTransactionHash: hash,

--- a/src/swap.flows/USDT2ETHTOKEN.js
+++ b/src/swap.flows/USDT2ETHTOKEN.js
@@ -95,14 +95,14 @@ export default (tokenName) => {
 
         () => {
           flow.swap.room.once('swap sign', () => {
-            debug('swap:flow')('swap sign!')
+            debug('swap.core:flow')('swap sign!')
             flow.finishStep({
               isParticipantSigned: true,
             }, { step: 'sign', silentError: true })
           })
 
           flow.swap.room.once('swap exists', () => {
-            debug('swap:flow')(`swap already exists`)
+            debug('swap.core:flow')(`swap already exists`)
           })
 
           // if I came late and he ALREADY send this, I request AGAIN
@@ -150,8 +150,8 @@ export default (tokenName) => {
             scriptValues = usdtScriptValues
           }
 
-          debug('swap:flow')('sellAmount', sellAmount)
-          debug('swap:flow')('scriptValues', scriptValues)
+          debug('swap.core:flow')('sellAmount', sellAmount)
+          debug('swap.core:flow')('scriptValues', scriptValues)
 
           let usdtFundingTransactionHash, usdtFunding
 
@@ -259,7 +259,7 @@ export default (tokenName) => {
 
           try {
             await flow.ethTokenSwap.withdraw(data, (hash) => {
-              debug('swap:flow')('withdraw tx hash', hash)
+              debug('swap.core:flow')('withdraw tx hash', hash)
 
               flow.setState({
                 ethSwapWithdrawTransactionHash: hash,

--- a/src/swap.orders/SwapOrders.js
+++ b/src/swap.orders/SwapOrders.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import BigNumber from 'bignumber.js'
 import SwapApp, { Collection, ServiceInterface, util, constants } from 'swap.app'
 import SwapRoom from 'swap.room'
@@ -43,7 +44,7 @@ const checkIncomeOrderFormat = (order) => {
   const isValid = util.typeforce.check(format, order, true)
 
   if (!isValid) {
-    console.log('Wrong income order format. Excepted:', format, 'got:', order)
+    debug('swap:orders')('Wrong income order format. Excepted:', format, 'got:', order)
   }
 
   return isValid
@@ -342,11 +343,11 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
     }
 
     SwapApp.services.room.on('accept request', function ({ fromPeer, orderId }) {
-      console.log('requestToPeer accept request', fromPeer)
+      debug('swap:orders')('requestToPeer accept request', fromPeer)
       if (peer === fromPeer) {
         this.unsubscribe()
 
-        console.log('requestToPeer IF')
+        debug('swap:orders')('requestToPeer IF')
 
         callback(orderId)
       }

--- a/src/swap.orders/SwapOrders.js
+++ b/src/swap.orders/SwapOrders.js
@@ -44,7 +44,7 @@ const checkIncomeOrderFormat = (order) => {
   const isValid = util.typeforce.check(format, order, true)
 
   if (!isValid) {
-    debug('swap:orders')('Wrong income order format. Excepted:', format, 'got:', order)
+    debug('swap.core:orders')('Wrong income order format. Excepted:', format, 'got:', order)
   }
 
   return isValid
@@ -343,11 +343,11 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
     }
 
     SwapApp.services.room.on('accept request', function ({ fromPeer, orderId }) {
-      debug('swap:orders')('requestToPeer accept request', fromPeer)
+      debug('swap.core:orders')('requestToPeer accept request', fromPeer)
       if (peer === fromPeer) {
         this.unsubscribe()
 
-        debug('swap:orders')('requestToPeer IF')
+        debug('swap.core:orders')('requestToPeer IF')
 
         callback(orderId)
       }

--- a/src/swap.room/SwapRoom.js
+++ b/src/swap.room/SwapRoom.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { constants, Events, ServiceInterface } from 'swap.app'
 
 
@@ -51,7 +52,7 @@ class SwapRoom extends ServiceInterface {
         })
       }))
       .on('error', (err) => {
-        console.log('IPFS error!', err)
+        debug('swap:room')('IPFS error!', err)
       })
   }
 
@@ -71,7 +72,7 @@ class SwapRoom extends ServiceInterface {
 
     this.roomName = this._config.roomName || defaultRoomName
 
-    console.log(`Using room: ${this.roomName}`)
+    debug('swap:room')(`Using room: ${this.roomName}`)
 
     this.connection = SwapApp.env.IpfsRoom(ipfsConnection, this.roomName, {
       pollInterval: 1000,
@@ -98,7 +99,7 @@ class SwapRoom extends ServiceInterface {
 
   _handleNewMessage = (message) => {
     const { from, data: rawData } = message
-    console.log('message from', from)
+    debug('swap:room')('message from', from)
 
     if (from === this.peer) {
       return
@@ -119,7 +120,7 @@ class SwapRoom extends ServiceInterface {
       return
     }
 
-    // console.log('parsedData', parsedData)
+    // debug('swap:room')('parsedData', parsedData)
 
     const recover = this._recoverMessage(data, sign)
 
@@ -255,8 +256,8 @@ class SwapRoom extends ServiceInterface {
       return
     }
 
-    console.log('sent message to peer', peer)
-    // console.log('message', message)
+    debug('swap:room')('sent message to peer', peer)
+    // debug('swap:room')('message', message)
 
     const { data, event }  = message
     const sign = this._signMessage(data)

--- a/src/swap.room/SwapRoom.js
+++ b/src/swap.room/SwapRoom.js
@@ -52,7 +52,7 @@ class SwapRoom extends ServiceInterface {
         })
       }))
       .on('error', (err) => {
-        debug('swap:room')('IPFS error!', err)
+        debug('swap.core:room')('IPFS error!', err)
       })
   }
 
@@ -72,7 +72,7 @@ class SwapRoom extends ServiceInterface {
 
     this.roomName = this._config.roomName || defaultRoomName
 
-    debug('swap:room')(`Using room: ${this.roomName}`)
+    debug('swap.core:room')(`Using room: ${this.roomName}`)
 
     this.connection = SwapApp.env.IpfsRoom(ipfsConnection, this.roomName, {
       pollInterval: 1000,
@@ -99,7 +99,7 @@ class SwapRoom extends ServiceInterface {
 
   _handleNewMessage = (message) => {
     const { from, data: rawData } = message
-    debug('swap:room')('message from', from)
+    debug('swap.core:room')('message from', from)
 
     if (from === this.peer) {
       return
@@ -120,7 +120,7 @@ class SwapRoom extends ServiceInterface {
       return
     }
 
-    // debug('swap:room')('parsedData', parsedData)
+    // debug('swap.core:room')('parsedData', parsedData)
 
     const recover = this._recoverMessage(data, sign)
 
@@ -256,8 +256,8 @@ class SwapRoom extends ServiceInterface {
       return
     }
 
-    debug('swap:room')('sent message to peer', peer)
-    // debug('swap:room')('message', message)
+    debug('swap.core:room')('sent message to peer', peer)
+    // debug('swap.core:room')('message', message)
 
     const { data, event }  = message
     const sign = this._signMessage(data)

--- a/src/swap.swap/Flow.js
+++ b/src/swap.swap/Flow.js
@@ -101,13 +101,13 @@ class Flow {
     SwapApp.env.storage.setItem(`flow.${this.swap.id}`, this.state)
   }
   finishStep(data, constraints) {
-    debug('swap:swap')(`on step ${this.state.step}, constraints =`, constraints)
+    debug('swap.core:swap')(`on step ${this.state.step}, constraints =`, constraints)
 
     if (constraints) {
       const { step, silentError } = constraints
 
       const n_step = this.stepNumbers[step]
-      debug('swap:swap')(`trying to finish step ${step} = ${n_step} when on step ${this.state.step}`)
+      debug('swap.core:swap')(`trying to finish step ${step} = ${n_step} when on step ${this.state.step}`)
 
       if (step && this.state.step != n_step) {
         if (silentError) {
@@ -120,7 +120,7 @@ class Flow {
       }
     }
 
-    debug('swap:swap')(`proceed to step ${this.state.step+1}, data=`, data)
+    debug('swap.core:swap')(`proceed to step ${this.state.step+1}, data=`, data)
 
     this.goNextStep(data)
   }

--- a/src/swap.swap/Flow.js
+++ b/src/swap.swap/Flow.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp from 'swap.app'
 import Room from './Room'
 
@@ -100,13 +101,13 @@ class Flow {
     SwapApp.env.storage.setItem(`flow.${this.swap.id}`, this.state)
   }
   finishStep(data, constraints) {
-    console.log(`on step ${this.state.step}, constraints =`, constraints)
+    debug('swap:swap')(`on step ${this.state.step}, constraints =`, constraints)
 
     if (constraints) {
       const { step, silentError } = constraints
 
       const n_step = this.stepNumbers[step]
-      console.log(`trying to finish step ${step} = ${n_step} when on step ${this.state.step}`)
+      debug('swap:swap')(`trying to finish step ${step} = ${n_step} when on step ${this.state.step}`)
 
       if (step && this.state.step != n_step) {
         if (silentError) {
@@ -119,7 +120,7 @@ class Flow {
       }
     }
 
-    console.log(`proceed to step ${this.state.step+1}, data=`, data)
+    debug('swap:swap')(`proceed to step ${this.state.step+1}, data=`, data)
 
     this.goNextStep(data)
   }

--- a/src/swap.swap/Room.js
+++ b/src/swap.swap/Room.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { Events } from 'swap.app'
 
 
@@ -24,7 +25,7 @@ class Room {
 
   on(eventName, handler) {
     SwapApp.services.room.on(eventName, ({ fromPeer, swapId, ...values }) => {
-      console.log(`on ${eventName} from ${fromPeer} at swap ${swapId}`)
+      debug('swap:room')(`on ${eventName} from ${fromPeer} at swap ${swapId}`)
       if (fromPeer === this.peer && swapId === this.swapId) {
         handler(values)
       }
@@ -35,7 +36,7 @@ class Room {
     const self = this
 
     SwapApp.services.room.on(eventName, function ({ fromPeer, swapId, ...values }) {
-      console.log(`once ${eventName} from ${fromPeer} at swap ${swapId}`)
+      debug('swap:room')(`once ${eventName} from ${fromPeer} at swap ${swapId}`)
       if (fromPeer === self.peer && swapId === self.swapId) {
         this.unsubscribe()
         handler(values)

--- a/src/swap.swap/Room.js
+++ b/src/swap.swap/Room.js
@@ -25,7 +25,7 @@ class Room {
 
   on(eventName, handler) {
     SwapApp.services.room.on(eventName, ({ fromPeer, swapId, ...values }) => {
-      debug('swap:room')(`on ${eventName} from ${fromPeer} at swap ${swapId}`)
+      debug('swap.core:room')(`on ${eventName} from ${fromPeer} at swap ${swapId}`)
       if (fromPeer === this.peer && swapId === this.swapId) {
         handler(values)
       }
@@ -36,7 +36,7 @@ class Room {
     const self = this
 
     SwapApp.services.room.on(eventName, function ({ fromPeer, swapId, ...values }) {
-      debug('swap:room')(`once ${eventName} from ${fromPeer} at swap ${swapId}`)
+      debug('swap.core:room')(`once ${eventName} from ${fromPeer} at swap ${swapId}`)
       if (fromPeer === self.peer && swapId === self.swapId) {
         this.unsubscribe()
         handler(values)

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import BigNumber from 'bignumber.js'
 import SwapApp, { Events, util,  } from 'swap.app'
 import Room from './Room'
@@ -50,13 +51,13 @@ class Swap {
 
     // Change destination address on run time
     this.room.on('set destination buy address', (data) => {
-      console.log("Other side change destination buy address", data);
+      debug('swap:swap')("Other side change destination buy address", data);
       this.update({
         destinationSellAddress: data.address
       })
     });
     this.room.on('set destination sell address', (data) => {
-      console.log("Other side change destination sell address", data);
+      debug('swap:swap')("Other side change destination sell address", data);
       this.update({
         destinationBuyAddress: data.address
       })

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -51,13 +51,13 @@ class Swap {
 
     // Change destination address on run time
     this.room.on('set destination buy address', (data) => {
-      debug('swap:swap')("Other side change destination buy address", data);
+      debug('swap.core:swap')("Other side change destination buy address", data);
       this.update({
         destinationSellAddress: data.address
       })
     });
     this.room.on('set destination sell address', (data) => {
-      debug('swap:swap')("Other side change destination sell address", data);
+      debug('swap.core:swap')("Other side change destination sell address", data);
       this.update({
         destinationBuyAddress: data.address
       })

--- a/src/swap.swaps/BtcSwap.js
+++ b/src/swap.swaps/BtcSwap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { SwapInterface, constants } from 'swap.app'
 import BigNumber from 'bignumber.js'
 
@@ -89,7 +90,7 @@ class BtcSwap extends SwapInterface {
 
     const { secretHash, ownerPublicKey, recipientPublicKey, lockTime } = data
 
-    console.log('DATA', data)
+    debug('swap:swaps')('DATA', data)
 
     const script = SwapApp.env.bitcoin.script.compile([
 
@@ -326,7 +327,7 @@ class BtcSwap extends SwapInterface {
     return new Promise(async (resolve, reject) => {
       try {
         const txRaw = await this.getWithdrawRawTransaction(data, isRefund, hashName)
-        console.log('raw tx withdraw', txRaw.toHex())
+        debug('swap:swaps')('raw tx withdraw', txRaw.toHex())
 
         if (typeof handleTransactionHash === 'function') {
           handleTransactionHash(txRaw.getId())

--- a/src/swap.swaps/BtcSwap.js
+++ b/src/swap.swaps/BtcSwap.js
@@ -90,7 +90,7 @@ class BtcSwap extends SwapInterface {
 
     const { secretHash, ownerPublicKey, recipientPublicKey, lockTime } = data
 
-    debug('swap:swaps')('DATA', data)
+    debug('swap.core:swaps')('DATA', data)
 
     const script = SwapApp.env.bitcoin.script.compile([
 
@@ -327,7 +327,7 @@ class BtcSwap extends SwapInterface {
     return new Promise(async (resolve, reject) => {
       try {
         const txRaw = await this.getWithdrawRawTransaction(data, isRefund, hashName)
-        debug('swap:swaps')('raw tx withdraw', txRaw.toHex())
+        debug('swap.core:swaps')('raw tx withdraw', txRaw.toHex())
 
         if (typeof handleTransactionHash === 'function') {
           handleTransactionHash(txRaw.getId())

--- a/src/swap.swaps/EosSwap.js
+++ b/src/swap.swaps/EosSwap.js
@@ -102,7 +102,7 @@ class EosSwap extends SwapInterface {
     const findSwapID = () => this.findSwapID({ btcOwner, eosOwner })
 
     const depositFunds = (swapID) => {
-      debug('swap:swaps')('depositFunds', swapID)
+      debug('swap.core:swaps')('depositFunds', swapID)
 
       return this.eos.transaction({
         actions: [

--- a/src/swap.swaps/EosSwap.js
+++ b/src/swap.swaps/EosSwap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { SwapInterface, constants } from 'swap.app'
 
 const amountToUnits = amount =>
@@ -101,7 +102,7 @@ class EosSwap extends SwapInterface {
     const findSwapID = () => this.findSwapID({ btcOwner, eosOwner })
 
     const depositFunds = (swapID) => {
-      console.log('depositFunds', swapID)
+      debug('swap:swaps')('depositFunds', swapID)
 
       return this.eos.transaction({
         actions: [

--- a/src/swap.swaps/EthSwap.js
+++ b/src/swap.swaps/EthSwap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, {constants, SwapInterface} from 'swap.app'
 import BigNumber from 'bignumber.js'
 import InputDataDecoder from 'ethereum-input-data-decoder'
@@ -65,11 +66,11 @@ class EthSwap extends SwapInterface {
   async create(data, handleTransactionHash) {
     const { secretHash, participantAddress, amount } = data
 
-    console.log('create before', this.gasPrice)
+    debug('swap:swaps')('create before', this.gasPrice)
 
     await this.updateGas()
 
-    console.log('create after', this.gasPrice)
+    debug('swap:swaps')('create after', this.gasPrice)
 
     const base = BigNumber(10).pow(18)
     const newAmount = new BigNumber(amount.toString()).times(base).integerValue().toNumber()
@@ -84,7 +85,7 @@ class EthSwap extends SwapInterface {
         gasPrice: this.gasPrice,
       }
 
-      console.log('params', params)
+      debug('swap:swaps')('params', params)
 
       const values = [ hash, participantAddress ]
 
@@ -148,7 +149,7 @@ class EthSwap extends SwapInterface {
         return
       }
 
-      console.log('swapExists', swap)
+      debug('swap:swaps')('swapExists', swap)
 
       const balance = swap ? parseInt(swap.balance) : 0
       resolve(balance > 0)
@@ -282,7 +283,7 @@ class EthSwap extends SwapInterface {
           from: SwapApp.services.auth.accounts.eth.address,
         })
 
-        console.log('secret ethswap.js', secret)
+        debug('swap:swaps')('secret ethswap.js', secret)
 
         const secretValue = secret && !/^0x0+/.test(secret) ? secret : null
 

--- a/src/swap.swaps/EthSwap.js
+++ b/src/swap.swaps/EthSwap.js
@@ -66,11 +66,11 @@ class EthSwap extends SwapInterface {
   async create(data, handleTransactionHash) {
     const { secretHash, participantAddress, amount } = data
 
-    debug('swap:swaps')('create before', this.gasPrice)
+    debug('swap.core:swaps')('create before', this.gasPrice)
 
     await this.updateGas()
 
-    debug('swap:swaps')('create after', this.gasPrice)
+    debug('swap.core:swaps')('create after', this.gasPrice)
 
     const base = BigNumber(10).pow(18)
     const newAmount = new BigNumber(amount.toString()).times(base).integerValue().toNumber()
@@ -85,7 +85,7 @@ class EthSwap extends SwapInterface {
         gasPrice: this.gasPrice,
       }
 
-      debug('swap:swaps')('params', params)
+      debug('swap.core:swaps')('params', params)
 
       const values = [ hash, participantAddress ]
 
@@ -149,7 +149,7 @@ class EthSwap extends SwapInterface {
         return
       }
 
-      debug('swap:swaps')('swapExists', swap)
+      debug('swap.core:swaps')('swapExists', swap)
 
       const balance = swap ? parseInt(swap.balance) : 0
       resolve(balance > 0)
@@ -283,7 +283,7 @@ class EthSwap extends SwapInterface {
           from: SwapApp.services.auth.accounts.eth.address,
         })
 
-        debug('swap:swaps')('secret ethswap.js', secret)
+        debug('swap.core:swaps')('secret ethswap.js', secret)
 
         const secretValue = secret && !/^0x0+/.test(secret) ? secret : null
 

--- a/src/swap.swaps/EthTokenSwap.js
+++ b/src/swap.swaps/EthTokenSwap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { SwapInterface, constants } from 'swap.app'
 import BigNumber from 'bignumber.js'
 import InputDataDecoder from 'ethereum-input-data-decoder'
@@ -168,10 +169,10 @@ class EthTokenSwap extends SwapInterface {
       const contractMethod = (targetWallet && (targetWallet!==participantAddress)) ? 'createSwapTarget' : 'createSwap'
 
       try {
-        console.log("Get gas fee");
+        debug('swap:swaps')("Get gas fee");
         const gasFee = await this.contract.methods[contractMethod](...values).estimateGas(params)
         params.gas = gasFee;
-        console.log("EthTokenSwap -> create -> gasFee",gasFee);
+        debug('swap:swaps')("EthTokenSwap -> create -> gasFee",gasFee);
         const result = await this.contract.methods[contractMethod](...values).send(params)
           .on('transactionHash', (hash) => {
             if (typeof handleTransactionHash === 'function') {
@@ -181,7 +182,7 @@ class EthTokenSwap extends SwapInterface {
           .on('error', (err) => {
             reject(err)
           })
-        console.log('result', result)
+        debug('swap:swaps')('result', result)
         resolve(result)
       }
       catch (err) {
@@ -203,7 +204,7 @@ class EthTokenSwap extends SwapInterface {
     return new Promise(async (resolve, reject) => {
       let swap
 
-      console.log(`swaps[${ownerAddress}, ${participantAddress}]`)
+      debug('swap:swaps')(`swaps[${ownerAddress}, ${participantAddress}]`)
 
       try {
         swap = await this.contract.methods.swaps(ownerAddress, participantAddress).call()
@@ -213,10 +214,10 @@ class EthTokenSwap extends SwapInterface {
         return
       }
 
-      console.log('swapExists', swap)
+      debug('swap:swaps')('swapExists', swap)
 
       const balance = swap && swap.balance ? parseInt(swap.balance) : 0
-      console.log(`resolve(${balance})`)
+      debug('swap:swaps')(`resolve(${balance})`)
 
       resolve(balance > 0)
     })
@@ -267,7 +268,7 @@ class EthTokenSwap extends SwapInterface {
       catch (err) {
         reject(err)
       }
-      console.log('balance', balance)
+      debug('swap:swaps')('balance', balance)
       resolve(balance)
     })
   }
@@ -297,13 +298,13 @@ class EthTokenSwap extends SwapInterface {
     // ---
   }
   async getTargetWallet(ownerAddress) {
-    console.log('EthTokenSwap->getTargetWallet');
+    debug('swap:swaps')('EthTokenSwap->getTargetWallet');
     return new Promise(async (resolve, reject) => {
       try {
         const targetWallet = await this.contract.methods.getTargetWallet(ownerAddress).call({
           from: SwapApp.services.auth.accounts.eth.address,
         })
-        console.log('EthTokenSwap->getTargetWallet',targetWallet);
+        debug('swap:swaps')('EthTokenSwap->getTargetWallet',targetWallet);
 
         resolve(targetWallet)
       }
@@ -336,7 +337,7 @@ class EthTokenSwap extends SwapInterface {
 
       try {
         const gasFee = await this.contract.methods.withdraw(_secret, ownerAddress).estimateGas(params);
-        console.log("EthTokenSwap -> withdraw -> gasFee",gasFee);
+        debug('swap:swaps')("EthTokenSwap -> withdraw -> gasFee",gasFee);
         params.gas = gasFee;
         const result = await this.contract.methods.withdraw(_secret, ownerAddress).send(params)
           .on('transactionHash', (hash) => {

--- a/src/swap.swaps/EthTokenSwap.js
+++ b/src/swap.swaps/EthTokenSwap.js
@@ -169,10 +169,10 @@ class EthTokenSwap extends SwapInterface {
       const contractMethod = (targetWallet && (targetWallet!==participantAddress)) ? 'createSwapTarget' : 'createSwap'
 
       try {
-        debug('swap:swaps')("Get gas fee");
+        debug('swap.core:swaps')("Get gas fee");
         const gasFee = await this.contract.methods[contractMethod](...values).estimateGas(params)
         params.gas = gasFee;
-        debug('swap:swaps')("EthTokenSwap -> create -> gasFee",gasFee);
+        debug('swap.core:swaps')("EthTokenSwap -> create -> gasFee",gasFee);
         const result = await this.contract.methods[contractMethod](...values).send(params)
           .on('transactionHash', (hash) => {
             if (typeof handleTransactionHash === 'function') {
@@ -182,7 +182,7 @@ class EthTokenSwap extends SwapInterface {
           .on('error', (err) => {
             reject(err)
           })
-        debug('swap:swaps')('result', result)
+        debug('swap.core:swaps')('result', result)
         resolve(result)
       }
       catch (err) {
@@ -204,7 +204,7 @@ class EthTokenSwap extends SwapInterface {
     return new Promise(async (resolve, reject) => {
       let swap
 
-      debug('swap:swaps')(`swaps[${ownerAddress}, ${participantAddress}]`)
+      debug('swap.core:swaps')(`swaps[${ownerAddress}, ${participantAddress}]`)
 
       try {
         swap = await this.contract.methods.swaps(ownerAddress, participantAddress).call()
@@ -214,10 +214,10 @@ class EthTokenSwap extends SwapInterface {
         return
       }
 
-      debug('swap:swaps')('swapExists', swap)
+      debug('swap.core:swaps')('swapExists', swap)
 
       const balance = swap && swap.balance ? parseInt(swap.balance) : 0
-      debug('swap:swaps')(`resolve(${balance})`)
+      debug('swap.core:swaps')(`resolve(${balance})`)
 
       resolve(balance > 0)
     })
@@ -268,7 +268,7 @@ class EthTokenSwap extends SwapInterface {
       catch (err) {
         reject(err)
       }
-      debug('swap:swaps')('balance', balance)
+      debug('swap.core:swaps')('balance', balance)
       resolve(balance)
     })
   }
@@ -298,13 +298,13 @@ class EthTokenSwap extends SwapInterface {
     // ---
   }
   async getTargetWallet(ownerAddress) {
-    debug('swap:swaps')('EthTokenSwap->getTargetWallet');
+    debug('swap.core:swaps')('EthTokenSwap->getTargetWallet');
     return new Promise(async (resolve, reject) => {
       try {
         const targetWallet = await this.contract.methods.getTargetWallet(ownerAddress).call({
           from: SwapApp.services.auth.accounts.eth.address,
         })
-        debug('swap:swaps')('EthTokenSwap->getTargetWallet',targetWallet);
+        debug('swap.core:swaps')('EthTokenSwap->getTargetWallet',targetWallet);
 
         resolve(targetWallet)
       }
@@ -337,7 +337,7 @@ class EthTokenSwap extends SwapInterface {
 
       try {
         const gasFee = await this.contract.methods.withdraw(_secret, ownerAddress).estimateGas(params);
-        debug('swap:swaps')("EthTokenSwap -> withdraw -> gasFee",gasFee);
+        debug('swap.core:swaps')("EthTokenSwap -> withdraw -> gasFee",gasFee);
         params.gas = gasFee;
         const result = await this.contract.methods.withdraw(_secret, ownerAddress).send(params)
           .on('transactionHash', (hash) => {

--- a/src/swap.swaps/LtcSwap.js
+++ b/src/swap.swaps/LtcSwap.js
@@ -91,7 +91,7 @@ class LtcSwap extends SwapInterface {
 
     const { secretHash, ownerPublicKey, recipientPublicKey, lockTime } = data
 
-    debug('swap:swaps')('DATA', data)
+    debug('swap.core:swaps')('DATA', data)
 
     const script = SwapApp.env.bitcoin.script.compile([
 
@@ -369,7 +369,7 @@ class LtcSwap extends SwapInterface {
     return new Promise(async (resolve, reject) => {
       try {
         const txRaw = await this.getWithdrawRawTransaction(data, isRefund, hashName)
-        debug('swap:swaps')('raw tx withdraw', txRaw.toHex())
+        debug('swap.core:swaps')('raw tx withdraw', txRaw.toHex())
 
         if (typeof handleTransactionHash === 'function') {
           handleTransactionHash(txRaw.getId())

--- a/src/swap.swaps/LtcSwap.js
+++ b/src/swap.swaps/LtcSwap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { SwapInterface, constants } from 'swap.app'
 
 
@@ -90,7 +91,7 @@ class LtcSwap extends SwapInterface {
 
     const { secretHash, ownerPublicKey, recipientPublicKey, lockTime } = data
 
-    console.log('DATA', data)
+    debug('swap:swaps')('DATA', data)
 
     const script = SwapApp.env.bitcoin.script.compile([
 
@@ -368,7 +369,7 @@ class LtcSwap extends SwapInterface {
     return new Promise(async (resolve, reject) => {
       try {
         const txRaw = await this.getWithdrawRawTransaction(data, isRefund, hashName)
-        console.log('raw tx withdraw', txRaw.toHex())
+        debug('swap:swaps')('raw tx withdraw', txRaw.toHex())
 
         if (typeof handleTransactionHash === 'function') {
           handleTransactionHash(txRaw.getId())

--- a/src/swap.swaps/UsdtSwap.js
+++ b/src/swap.swaps/UsdtSwap.js
@@ -90,7 +90,7 @@ class UsdtSwap extends SwapInterface {
   createScript(data) {
     const { secretHash, ownerPublicKey, recipientPublicKey, lockTime } = data
 
-    debug('swap:swaps')('DATA', data)
+    debug('swap.core:swaps')('DATA', data)
 
     const script = SwapApp.env.bitcoin.script.compile([
 
@@ -159,7 +159,7 @@ class UsdtSwap extends SwapInterface {
       console.error(err)
       return `Can't get funding tx outputs ${fundingTxHash}`
     }
-    debug('swap:swaps')(outputs)
+    debug('swap.core:swaps')(outputs)
 
     if (!outputs || outputs.length < 2) {
       return `Expected at least 2 outputs at funding tx ${fundingTxHash}, got: ${outputs}`
@@ -186,7 +186,7 @@ class UsdtSwap extends SwapInterface {
       const expectedOmniOutput = SwapApp.env.bitcoin.script.toASM(expectedOmniScript)
 
       if (expectedOmniOutput !== omniScript) {
-        debug('swap:swaps')(expectedOmniOutput, omniScript)
+        debug('swap.core:swaps')(expectedOmniOutput, omniScript)
         return `Expected first output value: `
         + expectedOmniOutput
         + `, got: `
@@ -264,7 +264,7 @@ class UsdtSwap extends SwapInterface {
           recipientPublicKey,
           lockTime)
 
-        debug('swap:swaps')('script address', scriptAddress)
+        debug('swap.core:swaps')('script address', scriptAddress)
         const keyPair = SwapApp.services.auth.accounts.btc
         const myBtcAddress = keyPair.getAddress()
 
@@ -273,7 +273,7 @@ class UsdtSwap extends SwapInterface {
 
 
         const unspents  = [ ...scriptUnspents, ...myUnspents ]
-        debug('swap:swaps')('unspents', unspents)
+        debug('swap.core:swaps')('unspents', unspents)
         const fundValue = DUST
         const feeValue  = 5000
 
@@ -319,8 +319,8 @@ class UsdtSwap extends SwapInterface {
 
         const tx = txRaw
 
-        debug('swap:swaps')('redeem tx hash', tx.getId())
-        debug('swap:swaps')(`redeem tx hex ${tx.toHex()}`)
+        debug('swap.core:swaps')('redeem tx hash', tx.getId())
+        debug('swap.core:swaps')(`redeem tx hex ${tx.toHex()}`)
 
         if (typeof handleTransactionHash === 'function') {
           handleTransactionHash(tx.getId())

--- a/src/swap.swaps/UsdtSwap.js
+++ b/src/swap.swaps/UsdtSwap.js
@@ -1,3 +1,4 @@
+import debug from 'debug'
 import SwapApp, { SwapInterface, constants } from 'swap.app'
 
 const FEE_VALUE = 2000 // satoshis TODO how to get this value
@@ -89,7 +90,7 @@ class UsdtSwap extends SwapInterface {
   createScript(data) {
     const { secretHash, ownerPublicKey, recipientPublicKey, lockTime } = data
 
-    console.log('DATA', data)
+    debug('swap:swaps')('DATA', data)
 
     const script = SwapApp.env.bitcoin.script.compile([
 
@@ -158,7 +159,7 @@ class UsdtSwap extends SwapInterface {
       console.error(err)
       return `Can't get funding tx outputs ${fundingTxHash}`
     }
-    console.log(outputs)
+    debug('swap:swaps')(outputs)
 
     if (!outputs || outputs.length < 2) {
       return `Expected at least 2 outputs at funding tx ${fundingTxHash}, got: ${outputs}`
@@ -185,7 +186,7 @@ class UsdtSwap extends SwapInterface {
       const expectedOmniOutput = SwapApp.env.bitcoin.script.toASM(expectedOmniScript)
 
       if (expectedOmniOutput !== omniScript) {
-        console.log(expectedOmniOutput, omniScript)
+        debug('swap:swaps')(expectedOmniOutput, omniScript)
         return `Expected first output value: `
         + expectedOmniOutput
         + `, got: `
@@ -263,7 +264,7 @@ class UsdtSwap extends SwapInterface {
           recipientPublicKey,
           lockTime)
 
-        console.log('script address', scriptAddress)
+        debug('swap:swaps')('script address', scriptAddress)
         const keyPair = SwapApp.services.auth.accounts.btc
         const myBtcAddress = keyPair.getAddress()
 
@@ -272,7 +273,7 @@ class UsdtSwap extends SwapInterface {
 
 
         const unspents  = [ ...scriptUnspents, ...myUnspents ]
-        console.log('unspents', unspents)
+        debug('swap:swaps')('unspents', unspents)
         const fundValue = DUST
         const feeValue  = 5000
 
@@ -318,8 +319,8 @@ class UsdtSwap extends SwapInterface {
 
         const tx = txRaw
 
-        console.log('redeem tx hash', tx.getId())
-        console.log(`redeem tx hex ${tx.toHex()}`)
+        debug('swap:swaps')('redeem tx hash', tx.getId())
+        debug('swap:swaps')(`redeem tx hex ${tx.toHex()}`)
 
         if (typeof handleTransactionHash === 'function') {
           handleTransactionHash(tx.getId())

--- a/src/swap.swaps/usdt/swap_script.js
+++ b/src/swap.swaps/usdt/swap_script.js
@@ -60,8 +60,6 @@ const createScript = (swap_secret_hash, Alice_pubkey, Bob_pubkey, locktime) => {
     bitcoin.opcodes.OP_ENDIF,
   ])
 
-  console.log(script)
-
   const scriptPubKey  = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(script))
   const scriptAddress = bitcoin.address.fromOutputScript(scriptPubKey, net)
 


### PR DESCRIPTION
```
DEBUG=swap:events node ... 
```

will silence any output except marked 'swap:events'

Как лучше назвать workspace? @nikdementev @noxonsu @shendel @7flash @sdwas 
 
- [ ] `swap:orders`
- [ ] `swap:orders`
- [ ] `swap:orders`
- [x] `swap.core:orders`
- [x] `swap.core:orders`
- [ ] `swap.core:orders`


![image](https://user-images.githubusercontent.com/1909384/49538757-337b9c80-f8dd-11e8-9231-71d3d40c1551.png)


Возможно, многие из этих логов нужно просто удалить, но с другой стороны, если есть возможность их мьютить, то наоборот, можно будет теперь добавить новых полезных логов