### PR TITLE
simple: room.ready unsubscribe from events

### DIFF
--- a/simple/src/helpers/on.js
+++ b/simple/src/helpers/on.js
@@ -6,9 +6,11 @@ export const on = (emitter, _event) =>
 export const onFinish = emitter =>
   new Promise(resolve => {
     if (emitter instanceof Swap) {
-      emitter.on('enter step', () => {
-       if (emitter.flow.state.isFinished)
-        resolve()
+      emitter.on('enter step', function () {
+        if (emitter.flow.state.isFinished) {
+          this.unsubscribe()
+          resolve()
+        }
       })
     }
   })


### PR DESCRIPTION
Проблема с on в том, что он никогда не отписывается от emitter
Проблема с once в том, что если вызвать ready дважды, второй раз он ничего не вернет (события уже не было)

Я стал кешировать ответы once. Наверное, это уже оверкилл, потому что теперь есть проблема с тем, что у разных emitter могут быть одинаковые _event, и тогда будет коллизия.



![image](https://user-images.githubusercontent.com/1909384/49729770-747e0300-fc87-11e8-8de9-fdede877de86.png)
