### PR TITLE
Корректный подсчет баланса на скрипте при внешнем пополнении

### DIFF
--- a/src/swap.flows/BTC2ETHTOKEN.js
+++ b/src/swap.flows/BTC2ETHTOKEN.js
@@ -201,7 +201,9 @@ export default (tokenName) => {
                   scriptBalance : Number(balance),
                   scriptUnconfirmedBalance : unconfirmedTotal
                 });
-                const balanceOnScript = BigInt(balanceSatoshi) + unconfirmedTotalSatoshi + BigInt(this.btcSwap.getTxFee( true ) );
+
+                //TODO miner fee
+                const balanceOnScript = BigInt(balanceSatoshi)// + BigInt(this.btcSwap.getTxFee( true ) );
                 const isEnoughMoney = sellAmount.multipliedBy(1e8).isLessThanOrEqualTo( balanceOnScript );
 
                 console.log(balanceOnScript)


### PR DESCRIPTION
Суть проблемы
В функции проверки баланса BTC скрипта https://github.com/swaponline/swap.core/blob/9455a6bb6d13f46ec26afacd20e4ba6164578e70/src/swap.flows/BTC2ETHTOKEN.js#L179
Запрашивались все транзакции на него
https://github.com/swaponline/swap.core/blob/9455a6bb6d13f46ec26afacd20e4ba6164578e70/src/swap.flows/BTC2ETHTOKEN.js#L185
(Это нужно было чтобы сохранить id транзакции для отображения https://github.com/swaponline/swap.core/blob/9455a6bb6d13f46ec26afacd20e4ba6164578e70/src/swap.flows/BTC2ETHTOKEN.js#L187)
И посчитать не подтвержденный баланс (confirmations)
https://github.com/swaponline/swap.core/blob/9455a6bb6d13f46ec26afacd20e4ba6164578e70/src/swap.flows/BTC2ETHTOKEN.js#L190

После этого запрашивался баланс на скрипте используя имеющуюся функцию https://github.com/swaponline/swap.core/blob/9455a6bb6d13f46ec26afacd20e4ba6164578e70/src/swap.flows/BTC2ETHTOKEN.js#L196
Которая возвращает вес (!!!) баланс, включая не подтвержденный

Из-за этого, при пополнении скрипта на сумму 50% и более https://github.com/swaponline/swap.core/blob/9455a6bb6d13f46ec26afacd20e4ba6164578e70/src/swap.flows/BTC2ETHTOKEN.js#L204
Происходил переход далее

Исправил подсчет - теперь для проверки используется только данные из getBalance
