### PR TITLE
flow: always save secret with 0x-prefix

### DIFF
--- a/src/swap.flows/BTC2ETH.js
+++ b/src/swap.flows/BTC2ETH.js
@@ -367,8 +367,10 @@ class BTC2ETH extends Flow {
     /* Secret hash generated - create BTC script - and only after this notify other part */
     this.createWorkBTCScript(secretHash);
 
+    const _secret = `0x${secret.replace(/^0x/, '')}`
+
     this.finishStep({
-      secret,
+      secret: _secret,
       secretHash,
     }, { step: 'submit-secret' })
   }

--- a/src/swap.flows/BTC2ETHTOKEN.js
+++ b/src/swap.flows/BTC2ETHTOKEN.js
@@ -365,8 +365,10 @@ export default (tokenName) => {
       /* Secret hash generated - create BTC script - and only after this notify other part */
       this.createWorkBTCScript(secretHash);
 
+      const _secret = `0x${secret.replace(/^0x/, '')}`
+
       this.finishStep({
-        secret,
+        secret: _secret,
         secretHash,
       }, { step: 'submit-secret' })
     }

--- a/src/swap.flows/ETH2BTC.js
+++ b/src/swap.flows/ETH2BTC.js
@@ -192,10 +192,13 @@ class ETH2BTC extends Flow {
           const secret = await flow.ethSwap.getSecretFromTxhash(ethSwapWithdrawTransactionHash)
 
           if (!flow.state.isEthWithdrawn && secret) {
-            debug('swap.core:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
+            const _secret = `0x${secret.replace(/^0x/, '')}`
+
+            debug('swap.core:flow')('got secret from tx', ethSwapWithdrawTransactionHash, _secret)
+
             flow.finishStep({
               isEthWithdrawn: true,
-              secret,
+              secret: _secret,
             }, { step: 'wait-withdraw-eth' })
           }
         })
@@ -218,13 +221,15 @@ class ETH2BTC extends Flow {
             if (secret) {
               clearInterval(checkSecretTimer)
 
-              if (flow.state.secret && secret !== flow.state.secret) {
-                throw new Error(`Secret already exists and it differs! ${secret} ≠ ${flow.state.secret}`)
+              const _secret = `0x${secret.replace(/^0x/, '')}`
+
+              if (flow.state.secret && _secret !== flow.state.secret) {
+                throw new Error(`Secret already exists and it differs! ${_secret} ≠ ${flow.state.secret}`)
               }
 
-              debug('swap.core:flow')('got secret from smart contract', secret)
+              debug('swap.core:flow')('got secret from smart contract', _secret)
               flow.finishStep({
-                secret,
+                secret: _secret,
                 isEthWithdrawn: true,
               }, { step: 'wait-withdraw-eth' })
             }

--- a/src/swap.flows/ETHTOKEN2BTC.js
+++ b/src/swap.flows/ETHTOKEN2BTC.js
@@ -212,11 +212,13 @@ export default (tokenName) => {
 
             const secret = await flow.ethTokenSwap.getSecretFromTxhash(ethSwapWithdrawTransactionHash)
 
+            const _secret = `0x${secret.replace(/^0x/, '')}`
+
             if (!flow.state.isEthWithdrawn && secret) {
-              debug('swap.core:flow')('got secret from tx', ethSwapWithdrawTransactionHash, secret)
+              debug('swap.core:flow')('got secret from tx', ethSwapWithdrawTransactionHash, _secret)
               flow.finishStep({
                 isEthWithdrawn: true,
-                secret,
+                secret: _secret,
               }, {step: 'wait-withdraw-eth'})
             }
           })
@@ -239,13 +241,15 @@ export default (tokenName) => {
               if (secret) {
                 clearInterval(checkSecretTimer)
 
-                if (flow.state.secret && secret !== flow.state.secret) {
-                  throw new Error(`Secret already exists and it differs! ${secret} ≠ ${flow.state.secret}`)
+                const _secret = `0x${secret.replace(/^0x/, '')}`
+
+                if (flow.state.secret && _secret !== flow.state.secret) {
+                  throw new Error(`Secret already exists and it differs! ${_secret} ≠ ${flow.state.secret}`)
                 }
 
-                debug('swap.core:flow')('got secret from smart contract', secret)
+                debug('swap.core:flow')('got secret from smart contract', _secret)
                 flow.finishStep({
-                  secret,
+                  secret: _secret,
                   isEthWithdrawn: true,
                 }, { step: 'wait-withdraw-eth' })
               }

--- a/src/swap.swaps/EthSwap.js
+++ b/src/swap.swaps/EthSwap.js
@@ -428,13 +428,13 @@ class EthSwap extends SwapInterface {
    * @returns {Promise<any>}
    */
   getSecretFromTxhash = (transactionHash) =>
-    this.repeatToTheResult(9, () => SwapApp.env.web3.eth.getTransaction(transactionHash)
+    this.repeatToTheResult(-1, () => SwapApp.env.web3.eth.getTransaction(transactionHash)
       .then(txResult => {
         try {
           const bytes32 = this.decoder.decodeData(txResult.input)
           return SwapApp.env.web3.utils.bytesToHex(bytes32.inputs[0]).split('0x')[1]
         } catch (err) {
-          console.error(err)
+          debug('swap.core:swaps')('Trying to fetch secret from tx: ' + err.message)
           return
         }
       }))

--- a/src/swap.swaps/EthTokenSwap.js
+++ b/src/swap.swaps/EthTokenSwap.js
@@ -489,13 +489,13 @@ class EthTokenSwap extends SwapInterface {
    * @returns {Promise<any>}
    */
   getSecretFromTxhash = (transactionHash) =>
-    this.repeatToTheResult(9, () => SwapApp.env.web3.eth.getTransaction(transactionHash)
+    this.repeatToTheResult(-1, () => SwapApp.env.web3.eth.getTransaction(transactionHash)
       .then(txResult => {
         try {
           const bytes32 = this.decoder.decodeData(txResult.input)
           return SwapApp.env.web3.utils.bytesToHex(bytes32.inputs[0]).split('0x')[1]
         } catch (err) {
-          console.error(err)
+          debug('swap.core:swaps')('Trying to fetch secret from tx: ' + err.message)
           return
         }
       }))


### PR DESCRIPTION
- Ошибка при проверке секрета #217 
- Осторожно, возможно, измененная форма секрета может что-то сломать: нужно тестировать
- В функции `getSecretFromTxHash` заменил 9 попыток на бесконечность. Комиссию платить не нужно, поэтому смысла останавливаться после 9 попыток не вижу
- С другой стороны, непонятно, когда остановиться, если все никак секрет получить не удается?

Проверено:
- [x] BTC2ETH
- [x] ETH2BTC
- [x] ERC20-BTC
- [x] BTC-ERC20
