### PR TITLE
swap.orders: hard-cap 10 requests to any order (prevent localstorage overflow)

### DIFF
--- a/src/swap.orders/Order.js
+++ b/src/swap.orders/Order.js
@@ -55,7 +55,7 @@ class Order {
 
   _onMount() {
     SwapApp.services.room.on('request swap', ({ orderId, participant, destination }) => {
-      if (orderId === this.id && !this.requests.find(({ participant: { peer } }) => peer === participant.peer)) {
+      if (orderId === this.id && this.requests.length < 10 && !this.requests.find(({ participant: { peer } }) => peer === participant.peer)) {
         this.requests.push({ participant, destination, isPartial: false })
 
         events.dispatch('new order request', {


### PR DESCRIPTION
Больше 10 запросов – сначала разберись с теми, что были до этого, потом будешь получать новые