### PR TITLE
Методы для скрытия и показа ордеров

### DIFF
--- a/src/swap.orders/Order.js
+++ b/src/swap.orders/Order.js
@@ -38,6 +38,7 @@ class Order {
     this.isRequested      = false // outcome request status
     this.isProcessing     = false // if swap isProcessing
     this.isPartial        = false
+    this.isHidden         = false
 
     this.partialHandler   = {
       buyAmount: () => false,

--- a/src/swap.orders/SwapOrders.js
+++ b/src/swap.orders/SwapOrders.js
@@ -339,6 +339,12 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
   }
 
   hideMyOrders() {
+    this.items.forEach((order) => {
+      if (order && order.owner && order.owner.peer === this.app.services.room.peer) {
+        order.isHidden = true
+      }
+    })
+    this._saveMyOrders()
     this.app.services.room.sendMessageRoom({
       event: 'hide orders',
       data: {},
@@ -346,10 +352,21 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
   }
 
   showMyOrders() {
+    this.items.forEach((order) => {
+      if (order && order.owner && order.owner.peer === this.app.services.room.peer) {
+        order.isHidden = false
+      }
+    })
+    this._saveMyOrders()
     this.app.services.room.sendMessageRoom({
       event: 'show orders',
       data: {},
     })
+  }
+
+  hasHiddenOrders() {
+    let myHiddenOrders = this.items.filter(({ isHidden, owner: { peer } }) => (peer === this.app.services.room.peer && isHidden))
+    return myHiddenOrders.length ? true : false
   }
 
   /**

--- a/src/swap.orders/SwapOrders.js
+++ b/src/swap.orders/SwapOrders.js
@@ -32,6 +32,7 @@ const checkIncomeOrderFormat = (order) => {
     isProcessing: '?Boolean',
     isRequested: '?Boolean',
     isPartial: '?Boolean',
+    isHidden: '?Boolean',
     destination: util.typeforce.t.maybe({
       ownerAddress: '?String',
       participantAddress: '?String',
@@ -80,6 +81,8 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
     this.app.services.room.on('new orders', this._handleNewOrders)
     this.app.services.room.on('new order', this._handleNewOrder)
     this.app.services.room.on('remove order', this._handleRemoveOrder)
+    this.app.services.room.on('hide orders', this._handleHideOrders)
+    this.app.services.room.on('show orders', this._handleShowOrders)
 
     this.getUniqueId = (() => {
       let id = Date.now()
@@ -89,6 +92,22 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
 
   _handleReady = () => {
     this._persistMyOrders()
+  }
+
+  _handleHideOrders = ({ fromPeer }) => {
+    this.items.forEach((order) => {
+      if (order && order.owner && order.owner.peer === fromPeer) {
+        order.isHidden = true
+      }
+    })
+  }
+
+  _handleShowOrders = ({ fromPeer }) => {
+    this.items.forEach((order) => {
+      if (order && order.owner && order.owner.peer === fromPeer) {
+        order.isHidden = false
+      }
+    })
   }
 
   _handleUserOnline = (peer) => {
@@ -108,6 +127,7 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
         'isRequested',
         'isProcessing',
         'isPartial',
+        'isHidden',
         'destination',
       ))
 
@@ -264,6 +284,7 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
       'isRequested',
       'isProcessing',
       'isPartial',
+      'isHidden',
       'destination',
     ))
 
@@ -308,12 +329,27 @@ class SwapOrders extends aggregation(ServiceInterface, Collection) {
           'isRequested',
           'isProcessing',
           'isPartial',
+          'isHidden',
           'destination',
         ),
       },
     })
 
     return order
+  }
+
+  hideMyOrders() {
+    this.app.services.room.sendMessageRoom({
+      event: 'hide orders',
+      data: {},
+    })
+  }
+
+  showMyOrders() {
+    this.app.services.room.sendMessageRoom({
+      event: 'show orders',
+      data: {},
+    })
   }
 
   /**


### PR DESCRIPTION
У ордеров появился параметр isHidden (по умолчанию false)
При перезагрузке, параметр принимает значение false

SwapApp.services.orders.hideMyOrders() - сообщает всем участникам, что нужно скрыть (поставить isHidden = true) для ордеров текущего пользователя
SwapApp.services.orders.showMyOrders() - сообщает, что нужно проставить isHidden = false

Назначение
Эти функции и параметры будут использовать сами приложения, в зависимости от логики, которую они используют (поддерживают несколько свапов одновременно или нет)

Пример для реакта:
- в оредербуке не будет показывать ордера у которых (isHidden=true)
- в партиал не будет показывать ордера у которых (isHidden=true)
- в начале свапа, продавец скрывает свои ордера
- в конце свапа, продавец заново их включает

