### PR TITLE
Учитывать комиссию при создании BTC (BCH) скрипта

### DIFF
--- a/src/swap.flows/BCH2ETH.js
+++ b/src/swap.flows/BCH2ETH.js
@@ -524,13 +524,18 @@ class BCH2ETH extends Flow {
     })
 
     const balance = await this.bchSwap.fetchBalance(this.app.services.auth.accounts.bch.getAddress())
-    const isEnoughMoney = sellAmount.isLessThanOrEqualTo(balance)
+    const txFee = await this.bchSwap.estimateFeeValue({ method: 'swap', fixed: true })
+
+    const needAmount = sellAmount.plus(txFee)
+    const isEnoughMoney = needAmount.isLessThanOrEqualTo(balance)
 
     if (!isEnoughMoney) {
-      console.error(`Not enough money: ${balance} < ${sellAmount}`)
+      console.error(`Not enough money: ${balance} < ${needAmount} (${sellAmount} + txFee ${txFee})`)
     }
     this.finishStep({
       balance,
+      createScriptFee: txFee,
+      createScriptNeedAmount: needAmount,
       isBalanceFetching: false,
       isBalanceEnough: isEnoughMoney,
     }, { step: 'sync-balance' })

--- a/src/swap.flows/BTC2ETHTOKEN.js
+++ b/src/swap.flows/BTC2ETHTOKEN.js
@@ -544,13 +544,18 @@ export default (tokenName) => {
       })
 
       const balance = await this.btcSwap.fetchBalance(this.app.services.auth.accounts.btc.getAddress())
-      const isEnoughMoney = sellAmount.isLessThanOrEqualTo(balance)
+      const txFee = await this.btcSwap.estimateFeeValue({ method: 'swap', fixed: true })
+
+      const needAmount = sellAmount.plus(txFee)
+      const isEnoughMoney = needAmount.isLessThanOrEqualTo(balance)
 
       if (!isEnoughMoney) {
-        console.error(`Not enough money: ${balance} < ${sellAmount}`)
+        console.error(`Not enough money: ${balance} < ${needAmount} (${sellAmount} + txFee ${txFee})`)
       }
       this.finishStep({
         balance,
+        createScriptFee: txFee,
+        createScriptNeedAmount: needAmount,
         isBalanceFetching: false,
         isBalanceEnough: isEnoughMoney,
       }, { step: 'sync-balance' })


### PR DESCRIPTION
Решение проблемы 
https://github.com/swaponline/swap.react/issues/1930

Теперь при проверке баланса, перед созданием скрипта учитывает комиссию
Так-же добавлены новые поля в состояние
createScriptFee - комиссия
createScriptNeedAmount - полная сумма включая комиссию, нужная для создания скрипта

![image](https://user-images.githubusercontent.com/1880211/58938422-724fb980-877d-11e9-8b17-cc2dc3478cda.png)

P.S. В реакте нужны правки, для отображения корректной суммы для пополнения скрипта - нужно указать, что вашего баланса не хватает для создания из-за фи, как в моем случае - сумма сделки была 0.0005 бтц, а на счету 0.0006 бтц