### PR TITLE
Время, когда был создан свап и функция для проверки таймаута

### DIFF
--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -20,6 +20,7 @@ class Swap {
     this.destinationBuyAddress  = null
     this.destinationSellAddress = null
     this.app                    = null
+    this.createUnixTimeStamp    = Math.floor(new Date().getTime() / 1000)
 
     this._attachSwapApp(app)
 
@@ -148,6 +149,7 @@ class Swap {
       'sellAmount',
       'destinationBuyAddress',
       'destinationSellAddress',
+      'createUnixTimeStamp',
     )
   }
 
@@ -155,6 +157,11 @@ class Swap {
     const data = this._pullRequiredData(this)
 
     this.app.env.storage.setItem(`swap.${this.id}`, data)
+  }
+
+  checkTimeout(timeoutUTS) {
+    // return false if timeout
+    return !((this.createUnixTimeStamp + timeoutUTS) > Math.floor(new Date().getTime() / 1000))
   }
 
   setDestinationBuyAddress(address) {

--- a/src/swap.swap/Swap.js
+++ b/src/swap.swap/Swap.js
@@ -160,7 +160,7 @@ class Swap {
   }
 
   checkTimeout(timeoutUTS) {
-    // return false if timeout
+    // return true if timeout passed
     return !((this.createUnixTimeStamp + timeoutUTS) > Math.floor(new Date().getTime() / 1000))
   }
 


### PR DESCRIPTION
Добавил поле createUnixTimeStamp - время, когда был создан свап
функция checkTimeout - на вход принимает кол-во секунд, вернет true, если указанное кол-во секунд уже прошло с момента создания свапа

P.S. Для старых свапов, которые уже есть в localStorage, время создания будет выставлено на текущее время, при первом обращении к нему (при извлечении свапа из хранилища)