### PR TITLE
Add segwit address checking and sending support (NEED HELP)

### DIFF
--- a/src/swap.app/util/typeforce.js
+++ b/src/swap.app/util/typeforce.js
@@ -19,7 +19,7 @@ const isCoinName = (value) => Object.values(constants.COINS).map((v) => v.toLowe
 const isCoinAddress = {
   [constants.COINS.eos]: (value) => typeof value === 'string' && /^[a-z][a-z1-5.]{0,10}([a-z1-5]|^\.)[a-j1-5]?$/.test(value),
   [constants.COINS.eth]: (value) => typeof value === 'string' && /^0x[A-Fa-f0-9]{40}$/.test(value),
-  [constants.COINS.btc]: (value) => typeof value === 'string' && /^[A-Za-z0-9]{26,35}$/.test(value),
+  [constants.COINS.btc]: (value) => typeof value === 'string' && /^(bc1|tb1|[123])[a-zA-HJ-NP-Z0-9]{25,39}$/.test(value),
   [constants.COINS.bch]: (value) => typeof value === 'string' && /^[A-Za-z0-9:]{26,54}$/.test(value),
   [constants.COINS.ltc]: (value) => typeof value === 'string' && /^[A-Za-z0-9]{34}$/.test(value),
   [constants.COINS.usdt]: (value) => typeof value === 'string',


### PR DESCRIPTION
## _But I am not sure that it is working for native segwit because there is no native segwit testnet explorers_

---------------

This is how i can see that
![image](https://user-images.githubusercontent.com/24671211/61468183-8b0adc00-a985-11e9-914f-e87bb5dd05a5.png)

--------------------

Same addresses:
**Private Key WIF**: `cNtxTcxRTPKvV9oQtMcouxSDFoW9K6SFNxoQ36WVj2gRJCsEE17R`


https://segwitaddress.org/bech32/?testnet=true
 - `tb1qj4nhazrpvevst442e44xh4lfvjzpqm98kac9pq`

![image](https://user-images.githubusercontent.com/24671211/61468248-a249c980-a985-11e9-8365-f75f999e22ea.png)
----------
https://segwitaddress.org/?testnet=true
 - `2MyTmjwnakQsG8ez12f38RirGSGe4pMtkkP`

![image](https://user-images.githubusercontent.com/24671211/61468301-b392d600-a985-11e9-9703-cbd61d9dad47.png)

