### PR TITLE
skip unknown coins when validate order

### DIFF
--- a/src/swap.orders/SwapOrders.js
+++ b/src/swap.orders/SwapOrders.js
@@ -8,6 +8,10 @@ import Order from './Order'
 
 
 const checkIncomeOrderFormat = (order) => {
+  // Skip unkronw sell-buy currency
+  if (order && order.buyCurrency && !util.typeforce.isCoinName(order.buyCurrency)) return false
+  if (order && order.sellCurrency && !util.typeforce.isCoinName(order.sellCurrency)) return false
+
   const format = {
     id: '?String',
     owner: {


### PR DESCRIPTION
Если размещен ордер, в котором используется монета, которой нет в конфигурации клиента, функция checkIncomeOrderFormat возвращает false без ошибки и предупреждения
Актуально в связке с виджетами
Если в виджете для токена 'TOKEN4YOU' разместили ордер, то у других клиентов кора (бот, реакт) появлялась ошибка, о неправильном формате входящего ордера
![image](https://user-images.githubusercontent.com/1880211/63032320-40b24780-bebe-11e9-991a-26e7cd874a1e.png)
